### PR TITLE
Improved JSON key logic

### DIFF
--- a/src/Plugin/DataType/StrawberryDataByKeyProvider.php
+++ b/src/Plugin/DataType/StrawberryDataByKeyProvider.php
@@ -11,7 +11,7 @@ namespace Drupal\strawberryfield\Plugin\DataType;
 use Drupal\Core\TypedData\TypedData;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 
-
+//@TODO refactor to same as \Drupal\strawberryfield\Plugin\DataType\StrawberryKeysFromJson
 class StrawberryDataByKeyProvider extends TypedData
 {
 
@@ -42,11 +42,8 @@ class StrawberryDataByKeyProvider extends TypedData
 
     $flattened = [];
     StrawberryfieldJsonHelper::arrayToFlatCommonkeys($jsonArray,$flattened, TRUE );
-    // @ TODO research moving this to \Drupal\Core\TypedData\Plugin\DataType\Map
-    // Solr is having issues dealing with that type
-    // but would allow us to avoid imploding and then deimploding
 
-    // Also, see if we need to quote everything
+    // @TODO, see if we need to quote everything
     if (isset($flattened[$needle])){
       $values[] = implode(",", $flattened[$needle]);
     }
@@ -63,8 +60,6 @@ class StrawberryDataByKeyProvider extends TypedData
     }
     // Right now we are just joining all values in a large string
     $this->processed = implode(",", $values);
-    // @TODO refactor this whole class to be a ItemList.
-    // @TODO refactor solr to be able to process MapData Type
 
     return $this->processed;
   }

--- a/src/Plugin/DataType/StrawberryKeysFromJson.php
+++ b/src/Plugin/DataType/StrawberryKeysFromJson.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/18/18
+ * Time: 8:21 PM
+ */
+
+namespace Drupal\strawberryfield\Plugin\DataType;
+
+use Drupal\Core\TypedData\DataDefinitionInterface;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedData;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\Core\TypedData\ListInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Drupal\Core\TypedData\Plugin\DataType\ItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+
+
+class StrawberryKeysFromJson extends ItemList {
+
+  /**
+   * Cached processed value.
+   *
+   * @var array|null
+   */
+  protected $processed = NULL;
+
+  /**
+   * Whether the values have already been computed or not.
+   *
+   * @var bool
+   */
+
+  protected $computed = FALSE;
+
+  /**
+   * Keyed array of items.
+   *
+   * @var \Drupal\Core\TypedData\TypedDataInterface[]
+   */
+  protected $list = [];
+
+  public function getValue() {
+    if ($this->processed == NULL) {
+      $this->process();
+    }
+    $values = [];
+    foreach ($this->list as $delta => $item) {
+      $values[$delta] = $item->getValue();
+    }
+    return $values;
+  }
+
+  public function process($langcode = NULL)
+  {
+    if ($this->processed !== NULL) {
+      return $this->processed;
+    }
+    $values = [];
+    $item = $this->getParent();
+
+    // Should 10 be enough? this is json-ld not github.. so maybe...
+    $jsonArray = json_decode($item->value,true,10);
+    //@TODO deal with JSON exceptions as we have done before
+
+    $flattened = [];
+    $flattened = StrawberryfieldJsonHelper::arrayToFlatJsonPropertypaths($jsonArray);
+    $this->processed = array_keys($flattened);
+    $this->computed = TRUE;
+    foreach ($this->processed as $delta => $item) {
+      $this->list[$delta] = $this->createItem($delta, $item);
+    }
+  }
+
+  /**
+   * Ensures that values are only computed once.
+   */
+  protected function ensureComputedValue() {
+    if ($this->computed === FALSE) {
+      $this->process();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setValue($values, $notify = TRUE) {
+    // Nothing to set
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getString() {
+    $this->ensureComputedValue();
+    return parent::getString();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($index) {
+    if (!is_numeric($index)) {
+      throw new \InvalidArgumentException('Unable to get a value with a non-numeric delta in a list.');
+    }
+    $this->ensureComputedValue();
+
+    return isset($this->list[$index]) ? $this->list[$index] : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function set($index, $value) {
+    $this->ensureComputedValue();
+    return parent::set($index, $value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function appendItem($value = NULL) {
+    $this->ensureComputedValue();
+    return parent::appendItem($value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function removeItem($index) {
+    $this->ensureComputedValue();
+    return parent::removeItem($index);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() {
+    $this->ensureComputedValue();
+    return parent::isEmpty();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function offsetExists($offset) {
+    $this->ensureComputedValue();
+    return parent::offsetExists($offset);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIterator() {
+    $this->ensureComputedValue();
+    return parent::getIterator();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function count() {
+    $this->ensureComputedValue();
+    return parent::count();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applyDefaultValue($notify = TRUE) {
+    return $this;
+  }
+
+
+}

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -4,11 +4,10 @@ namespace Drupal\strawberryfield\Plugin\Field\FieldType;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\strawberryfield\Tools\StrawberryKeyNameProvider;
-use Drupal\Core\TypedData\DataDefinition;
-use Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProviderManager;
+use Drupal\Core\TypedData\DataDefinition;;
 use Drupal\strawberryfield\Entity\keyNameProviderEntity;
 use Drupal\Component\Utility\Random;
+use Drupal\Core\TypedData\ListDataDefinition;
 
 /**
  * Provides a field type of strawberryfield.
@@ -63,12 +62,30 @@ use Drupal\Component\Utility\Random;
     */
    public static function propertyDefinitions(FieldStorageDefinitionInterface $field_definition) {
 
+
+     $reserverd_keys = [
+       'value',
+       'str_flatten_keys',
+     ];
+
      // @TODO mapDataDefinition() is the next step.
      $properties['value'] = DataDefinition::create('string')
        ->setLabel(t('JSON String'))
        ->setRequired(TRUE);
 
      // @See also https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21TypedData%21OptionsProviderInterface.php/interface/OptionsProviderInterface/8.5.x
+
+     // All properties as Property keys.
+     // Handy when dealing with Field formatters
+     $properties['str_flatten_keys'] = ListDataDefinition::create('string')
+       ->setLabel('JSON keys defined in this field')
+       ->setComputed(TRUE)
+       ->setClass(
+         '\Drupal\strawberryfield\Plugin\DataType\StrawberryKeysFromJson'
+       )
+       ->setInternal(FALSE)
+       ->setReadOnly(TRUE);
+
 
      $keynamelist = [];
 
@@ -103,11 +120,12 @@ use Drupal\Component\Utility\Random;
          );
        }
      }
-    // @TODO add also the flat representation as a property. Simply reuse our internal property helper
-    // Handy when dealing with Field formatters
-
 
      foreach ($keynamelist as $keyname) {
+       if (isset($reserverd_keys[$keyname])) {
+         // Avoid internal reserved keys
+         continue;
+       }
        $properties[$keyname] = DataDefinition::create('string')
          ->setLabel($keyname)
          ->setComputed(TRUE)
@@ -118,6 +136,8 @@ use Drupal\Component\Utility\Random;
          ->setSetting('jsonkey',$keyname)
          ->setReadOnly(TRUE);
      }
+
+
      return $properties;
    }
 

--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -156,6 +156,4 @@ class StrawberryfieldJsonHelper {
       return empty(array_filter(array_keys($sourcearray), 'is_string'));
   }
 
-
-
 }

--- a/strawberryfield.install
+++ b/strawberryfield.install
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @file
+ * Contains install and update functions for strawberryfield.
+ */
+
+use Drupal\Core\Language\LanguageInterface;
+use Drupal\taxonomy\Entity\Vocabulary;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Implements hook_install().
+ */
+
+function strawberry_install() {
+  $vid = "strawberryfield_voc_id";
+  $name = "Strawberryfield Metadata Keys";
+  $vocabularies = Vocabulary::loadMultiple();
+  if (!isset($vocabularies[$vid])) {
+
+    // Create a vocabulary to hold strawberryfield json keys.
+    $vocabulary = Vocabulary::create([
+      'name' => $name,
+      'description' => 'Holds Strawberry Field provided JSON Keys. Populated automatically on node save.',
+      'vid' => $vid,
+      'langcode' => LanguageInterface::LANGCODE_NOT_SPECIFIED,
+      'weight' => 0,
+    ]);
+    $vocabulary->save();
+  }
+  else {
+    // @TODO Vocabulary Already exist. Reuse as key provider.
+    $query = \Drupal::entityQuery('taxonomy_term');
+    $query->condition('vid', $vid);
+    $tids = $query->execute();
+  }
+}

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -118,6 +118,3 @@ function strawberryfield_node_presave(ContentEntityInterface $entity) {
     }
   }
 }
-
-
-

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -6,6 +6,7 @@
 
 use Drupal\Core\Cache\Cache;
 use Drupal\node\NodeInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
 
 
 /**
@@ -45,6 +46,78 @@ function strawberryfield_invalidate_fieldefinition_caches(NodeInterface $node) {
     if ($needscleaning) {
       \Drupal::service('plugin.manager.field.field_type')->clearCachedDefinitions();
     }
-
   }
 }
+
+function strawberryfield_node_presave(ContentEntityInterface $entity) {
+
+  $field_item_lists = $entity->getFields();
+  $newlycreatedcount = 0;
+  //@TODO refactor this as part of the AS/event driven architecture
+  // And make all this efforts JSON based plugins.
+  foreach ($field_item_lists as $field)
+    $type = $field->getFieldDefinition()->getType();
+  if ($type == 'strawberryfield_field') {
+    if (!$field->isEmpty) {
+      $jsonkeys = [];
+      $jsonkeys = $field->{'str_flatten_keys'};
+      foreach ($jsonkeys as $path) {
+        // Since our keys will be jsonpaths, we can explode them first by dot
+        $path_parts_raw = [];
+        $path_parts_raw = explode(".", $path);
+        $terms = [];
+        $terms = new CachingIterator(
+          new ArrayIterator($path_parts_raw)
+        );
+        $term_path = [];
+        foreach ($terms as $json_node) {
+          if ($terms->hasNext()) {
+            $next = $terms->getInnerIterator()->current();
+            if ($next == '[*]' || $next == '*') {
+              $term_path[] = $json_node . "." . $next;
+              continue;
+            }
+          }
+          if ($json_node != '[*]' && $json_node != '*') {
+            $term_path[] = $json_node;
+          }
+          $parent_id = 0;
+          foreach ($term_path as $path) {
+            $query = \Drupal::entityQuery('taxonomy_term');
+            $query->condition('vid', "strawberryfield_voc_id");
+            $query->condition('name', $path);
+            $query->condition('parent', $parent_id, 'IN');
+            $tids = $query->execute();
+            if (count($tids) == 0) {
+              $new_term = \Drupal\taxonomy\Entity\Term::create(
+                [
+                  'vid' => 'strawberryfield_voc_id',
+                  'name' => $path,
+                  'parent' => $parent_id,
+                ]
+              );
+              $newlycreatedcount++;
+              $new_term->enforceIsNew();
+              $new_term->save();
+              $parent_id = $new_term->id();
+            }
+            else {
+              //Assuming parent is there
+              foreach ($tids as $terms_id) {
+                $parent_id = $terms_id;
+              }
+            }
+
+          }
+        }
+      }
+    if ($newlycreatedcount > 0) {
+      \Drupal::messenger()->addStatus(t('New Terms added to the vocabulary'));
+    }
+
+    }
+  }
+}
+
+
+


### PR DESCRIPTION
This commit adds a few nice JSON key processing
- Finally, a working itemList data type computed property that Solr can see. Had
to work around the precomputing of initial `$list` values, since Drupal's Solr Module uses iterators instead of `getValue()`
- A JSON Path extractor, generator from data/metadata capable of detecting lists and named properties to add wildcards to paths. Used as a computed property in any
strawberry field (property name: `str_flatten_keys`). Actual method is found at `\Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper::arrayToFlatJsonPropertypaths`. Wildcard conversion works by detecting if a substructure is of type:
  - Object (or associative array when casted) or 
If Object and keys are URI, assume those are identifiers (in a semantic way) or at least can vary a lot, so are replaced by an `.*.`
  - Array (Numeric indexed Array when casted). 
In case of Array, JSON Path gets a `.[*]` added. See https://restfulapi.net/json-jsonpath/ for a better explanation

- A new Vocabulary deployed on install. This vocabulary is used to keep track (in hierarchy!) of valid JSON Path fragments to access our Metadata internal structure. In simple words, its an Vocabulary builder based on existing(or newly added/updated) metadata. Valid Uses are more than the ones I can imagine at 2:00 AM.
- On Node with Strawberry field save (exactly on presave), Keys are extracted as JSON Paths, split back and added as Taxonomy terms, with cool! Hierarchies are created automagically.

 The implementation works, indexes in Solr and we get way more flexibility and stability potential of this is 345%