### PR TITLE
Strawberry field properties exposed to Drupal properly as a list of items

### DIFF
--- a/src/Plugin/DataType/StrawberryValuesFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesFromJson.php
@@ -79,9 +79,13 @@ class StrawberryValuesFromJson extends ItemList {
     $flattened = [];
     StrawberryfieldJsonHelper::arrayToFlatCommonkeys($jsonArray,$flattened, TRUE );
     // @TODO, see if we need to quote everything
-    if (isset($flattened[$needle])){
-      $values[] = $flattened[$needle];
+    if (isset($flattened[$needle]) && is_array($flattened[$needle])){
+      $values[] = array_map('trim', $flattened[$needle]);
     }
+    elseif (isset($flattened[$needle])) {
+      $values[] = trim($flattened[$needle]);
+    }
+
 
     /*foreach ($flattened as $graphitems) {
       if (isset($graphitems[$needle])) {

--- a/src/Plugin/DataType/StrawberryValuesFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesFromJson.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/18/18
+ * Time: 8:21 PM
+ */
+
+namespace Drupal\strawberryfield\Plugin\DataType;
+
+use Drupal\Core\TypedData\DataDefinitionInterface;
+use Drupal\Core\TypedData\TraversableTypedDataInterface;
+use Drupal\Core\TypedData\TypedData;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\Core\TypedData\ListInterface;
+use Drupal\Core\TypedData\TypedDataInterface;
+use Drupal\Core\TypedData\Plugin\DataType\ItemList;
+use Drupal\Core\TypedData\ComputedItemListTrait;
+
+
+class StrawberryValuesFromJson extends ItemList {
+
+  /**
+   * Cached processed value.
+   *
+   * @var array|null
+   */
+  protected $processed = NULL;
+
+  /**
+   * Whether the values have already been computed or not.
+   *
+   * @var bool
+   */
+
+  protected $computed = FALSE;
+
+  /**
+   * Keyed array of items.
+   *
+   * @var \Drupal\Core\TypedData\TypedDataInterface[]
+   */
+  protected $list = [];
+
+  public function getValue() {
+    if ($this->processed == NULL) {
+      $this->process();
+    }
+    $values = [];
+    foreach ($this->list as $delta => $item) {
+      $values[$delta] = $item->getValue();
+    }
+    return $values;
+  }
+
+  /**
+   * @param null $langcode
+   *
+   * @return array|null
+   */
+  public function process($langcode = NULL)
+  {
+    if ($this->processed !== NULL) {
+      return $this->processed;
+    }
+    $values = [];
+    $item = $this->getParent();
+
+    // Should 10 be enough? this is json-ld not github.. so maybe...
+    $jsonArray = json_decode($item->value,true,10);
+    //@TODO deal with JSON exceptions as we have done before
+
+    $definition = $this->getDataDefinition();
+
+    // This key is passed by the property definition in the field class
+    $needle = $definition['settings']['jsonkey'];
+
+    $flattened = [];
+    StrawberryfieldJsonHelper::arrayToFlatCommonkeys($jsonArray,$flattened, TRUE );
+    // @TODO, see if we need to quote everything
+    if (isset($flattened[$needle])){
+      $values[] = $flattened[$needle];
+    }
+
+    /*foreach ($flattened as $graphitems) {
+      if (isset($graphitems[$needle])) {
+        if (is_array($graphitems[$needle])) {
+          $values[] = implode(",", $graphitems[$needle]);
+        }
+        else {
+          $values[] = $graphitems[$needle];
+        }
+      }
+
+    }*/
+
+    $this->processed = array_values($values);
+    $this->computed = TRUE;
+    foreach ($this->processed as $delta => $item) {
+      $this->list[$delta] = $this->createItem($delta, $item);
+    }
+  }
+
+  /**
+   * Ensures that values are only computed once.
+   */
+  protected function ensureComputedValue() {
+    if ($this->computed === FALSE) {
+      $this->process();
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setValue($values, $notify = TRUE) {
+    // Nothing to set
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getString() {
+    $this->ensureComputedValue();
+    return parent::getString();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($index) {
+    if (!is_numeric($index)) {
+      throw new \InvalidArgumentException('Unable to get a value with a non-numeric delta in a list.');
+    }
+    $this->ensureComputedValue();
+
+    return isset($this->list[$index]) ? $this->list[$index] : NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function set($index, $value) {
+    $this->ensureComputedValue();
+    return parent::set($index, $value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function appendItem($value = NULL) {
+    $this->ensureComputedValue();
+    return parent::appendItem($value);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function removeItem($index) {
+    $this->ensureComputedValue();
+    return parent::removeItem($index);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() {
+    $this->ensureComputedValue();
+    return parent::isEmpty();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function offsetExists($offset) {
+    $this->ensureComputedValue();
+    return parent::offsetExists($offset);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getIterator() {
+    $this->ensureComputedValue();
+    return parent::getIterator();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function count() {
+    $this->ensureComputedValue();
+    return parent::count();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applyDefaultValue($notify = TRUE) {
+    return $this;
+  }
+
+
+}

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -126,11 +126,11 @@ use Drupal\Core\TypedData\ListDataDefinition;
          // Avoid internal reserved keys
          continue;
        }
-       $properties[$keyname] = DataDefinition::create('string')
+       $properties[$keyname] = ListDataDefinition::create('string')
          ->setLabel($keyname)
          ->setComputed(TRUE)
          ->setClass(
-           '\Drupal\strawberryfield\Plugin\DataType\StrawberryDataByKeyProvider'
+           '\Drupal\strawberryfield\Plugin\DataType\StrawberryValuesFromJson'
          )
          ->setInternal(FALSE)
          ->setSetting('jsonkey',$keyname)

--- a/src/Plugin/StrawberryfieldKeyNameProvider/JsonldKeyNameProvider.php
+++ b/src/Plugin/StrawberryfieldKeyNameProvider/JsonldKeyNameProvider.php
@@ -97,6 +97,7 @@ class JsonldKeyNameProvider extends StrawberryfieldKeyNameProviderBase {
 
     $processedvalues = $this->getCacheTheKeys();
     $validkeys = [];
+    $extrakeys = [];
     if (empty($processedvalues)) {
       $jsonldcontext = StrawberryfieldJsonHelper::SIMPLE_JSONLDCONTEXT;
       $processedvalues = json_decode($jsonldcontext, TRUE);
@@ -104,6 +105,7 @@ class JsonldKeyNameProvider extends StrawberryfieldKeyNameProviderBase {
     }
     //user extra provided keys, if any.
     $extrakeys = explode(",",$this->getConfiguration()['keys']);
+    $extrakeys = array_map('trim', $extrakeys);
     $extrakeys = !empty($extrakeys) ? array_fill_keys($extrakeys,'stub'): [];
     $jsonld_reservedkeys = [
       '@context',

--- a/strawberryfield.install
+++ b/strawberryfield.install
@@ -7,6 +7,8 @@
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\taxonomy\Entity\Vocabulary;
 use Drupal\taxonomy\Entity\Term;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\field\Entity\FieldConfig;
 
 /**
  * Implements hook_install().
@@ -27,6 +29,17 @@ function strawberry_install() {
       'weight' => 0,
     ]);
     $vocabulary->save();
+    // Add a translatable field to the vocabulary.
+    $fieldstorage = FieldStorageConfig::create(array(
+      'field_name' => 'field_jsonpath',
+      'entity_type' => 'taxonomy_term',
+      'type' => 'text',
+    ));
+    $fieldstorage->save();
+
+    $field = FieldConfig::create(['field_storage' => $fieldstorage, 'bundle' => $vid]);
+    $field->save();
+
   }
   else {
     // @TODO Vocabulary Already exist. Reuse as key provider.

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -83,7 +83,9 @@ function strawberryfield_node_presave(ContentEntityInterface $entity) {
           }
           $parent_id = 0;
           $term_path = array_filter($term_path);
+          $breadcrumb = '';
           foreach ($term_path as $path) {
+            $breadcrumb = empty($breadcrumb)? $path: $breadcrumb.'.'.$path;
             $query = \Drupal::entityQuery('taxonomy_term');
             $query->condition('vid', "strawberryfield_voc_id");
             $query->condition('name', $path);
@@ -95,6 +97,7 @@ function strawberryfield_node_presave(ContentEntityInterface $entity) {
                   'vid' => 'strawberryfield_voc_id',
                   'name' => $path,
                   'parent' => $parent_id,
+                  'field_jsonpath' => $breadcrumb,
                 ]
               );
               $newlycreatedcount++;
@@ -119,3 +122,47 @@ function strawberryfield_node_presave(ContentEntityInterface $entity) {
     }
   }
 }
+
+/**
+ * Implements hook_entity_base_field_info().
+
+function strawberryfield_field_entity_base_field_info(EntityTypeInterface $entity_type) {
+  $fields = [];
+  if ($entity_types = _strawberryfieldable_get_entity_types()) {
+    // Adding field to entity types.
+    if (in_array($entity_type->id(), $entity_types)) {
+      $fields['strawberryfield_entityreferences'] = BaseFieldDefinition::create('entity_reference')
+        ->setName('strawberryfield_entityreferences')
+        ->setTargetEntityTypeId($entity_type->id())
+        ->setSetting('target_type', 'group_content')
+        ->setLabel(t('Related to'))
+        ->setTranslatable(FALSE)
+        ->setComputed(TRUE)
+        ->setCustomStorage(TRUE)
+        ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+        ->setClass('\Drupal\gcontent_field\Field\GcontentFieldItemList')
+        ->setDisplayConfigurable('form', TRUE)
+        ->setDisplayConfigurable('view', TRUE)
+        ->setDisplayOptions('view', [
+          'label' => 'hidden',
+          'type' => 'hidden',
+          'weight' => 50,
+        ]);
+    }
+  }
+  return $fields;
+}
+
+/**
+ * Get entities where the field should be added.
+
+function _strawberryfieldable_get_entity_types() {
+  $entity_types = [];
+  $field_map = \Drupal::entityManager()->getFieldMap();
+  foreach ($field_map['node'] as $field => $usage) {
+    if ($usage['type'] == "strawberryfield_field")
+      $entity_types = $entity_types + $usage['bundles'];
+  }
+}
+return $entity_types;
+} */


### PR DESCRIPTION
With Solr Search API 3.x-dev out and https://www.drupal.org/project/search_api_solr/issues/2828441 fixed we can now index our multivalued properties from Strawberry fields properly.

This pull adds:

- A new property value provider based on our Key plugins that returns a List of values. This allows of much better Views Integration, Faceting, etc. You name it
- Trims exposed property values, because Search API on one side indexes values as they are (even with leading spaces, and that is OK) but then cleans the spaces on Faceting display making faceted refining die on you.
- This Pull also brings some improvements on the already awesome Vocabulary Generation: preparing for a new JSON KEY provider to expose Strawberry fields that will use actual JSON PATHS collected from this vocabulary to ket Drupal know whats inside a/all strawberry fields.

## HOW TO USE:

You need to upgrade to Search API Solr 3.x-dev or higher to make use of multivalued properties (we held back on doing this before because of [issues/2828441](https://www.drupal.org/project/search_api_solr/issues/2828441) but now we are clear!

If running our (yours) docker deployment
```SHELL
docker exec -ti esmero-web bash -c 'composer require "drupal/search_api_solr:3.x-dev" --dev "solarium/solarium:^4.3.0-alpha.2" --dev '
````
Feel free to either stop your docker-compose or reload once you are done.

Now fetch the latest configuration files for your Solr Core (Using Solr 7.5). Search API 3.x adds some new requirements (like boost field) so you need to update this accordingly. 

```SHELL
cd $HOME
git clone https://github.com/esmero/archipelago-aws-demo
cd /persistent/solrconfig/
sudo rm -rf *  
sudo cp -R $HOME/ec2-user/archipelago-aws-demo/solrconfigford8/* .
docker-compose restart
docker exec -ti esmero-web bash -c "cd web;drush cr; drush updatedb;"
docker exec -ti esmero-web bash -c "composer update 'strawberryfield/strawberryfield'"
docker exec -ti esmero-web bash -c "cd web; drush search-api-clear;drush search-api-index;"
````

This will copy your new Solr Core settings over (see a [diff here](https://github.com/esmero/archipelago-aws-demo/commit/05f3b5371e8600991185b49f7fe56d822464dda5?diff=split), warning we also added some patches there), clear the index (you can always remove the core of course to be totally sure), updates the drupal database and settings for the new search api; needed because even the core settings like endpoints changed, and also drops the Solr index and reindexes everything. If something fails look at the logs and report back! 

After this JSON keys like `"types"`, or "`name_label`" will be indexed as a multi valued Solr field and can be used as facets directly.
 
