### PR TITLE
Coping with Core changes and WIP for allowing Strawberryfield to be normalized and exposed

### DIFF
--- a/src/Normalizer/StrawberryfieldFieldItemNormalizer.php
+++ b/src/Normalizer/StrawberryfieldFieldItemNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\strawberryfield\Normalizer;
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\serialization\Normalizer\FieldItemNormalizer;
+use Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem;
+use Drupal\serialization\Normalizer\EntityReferenceFieldItemNormalizerTrait;
+
+/**
+ * Adds the file URI to embedded file entities.
+ */
+class StrawberryfieldFieldItemNormalizer extends FieldItemNormalizer {
+
+  use EntityReferenceFieldItemNormalizerTrait;
+
+  /**
+   * The interface or class that this Normalizer supports.
+   *
+   * @var string
+   */
+  protected $supportedInterfaceOrClass = StrawberryFieldItem::class;
+
+  /**
+   * The entity repository.
+   *
+   * @var \Drupal\Core\Entity\EntityRepositoryInterface
+   */
+  protected $entityRepository;
+
+  /**
+   * Constructs a EntityReferenceFieldItemNormalizer object.
+   *
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   */
+  public function __construct(EntityRepositoryInterface $entity_repository) {
+    $this->entityRepository = $entity_repository;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($field_item, $format = NULL, array $context = []) {
+    //@TODO json decode and encode into array our strawberryfield
+    //@TODO check what options we can get from $context
+    $values = parent::normalize($field_item, $format, $context);
+
+
+    return $values;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function constructValue($data, $context) {
+
+    return parent::constructValue($data, $context);
+  }
+
+}

--- a/src/Plugin/DataType/StrawberryValuesFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesFromJson.php
@@ -78,14 +78,15 @@ class StrawberryValuesFromJson extends ItemList {
 
     $flattened = [];
     StrawberryfieldJsonHelper::arrayToFlatCommonkeys($jsonArray,$flattened, TRUE );
+
     // @TODO, see if we need to quote everything
     if (isset($flattened[$needle]) && is_array($flattened[$needle])){
-      $values[] = array_map('trim', $flattened[$needle]);
+      // This is an array, don't double nest to make the normalizer happy.
+      $values = array_map('trim', $flattened[$needle]);
     }
     elseif (isset($flattened[$needle])) {
       $values[] = trim($flattened[$needle]);
     }
-
 
     /*foreach ($flattened as $graphitems) {
       if (isset($graphitems[$needle])) {

--- a/src/Plugin/Field/FieldWidget/StrawberryDefaultWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryDefaultWidget.php
@@ -11,6 +11,7 @@ namespace Drupal\strawberryfield\Plugin\Field\FieldWidget;
 use Drupal\Core\Field\Plugin\Field\FieldWidget\StringTextareaWidget;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerTrait;
 /**
  * Plugin implementation of the 'strawberry_textarea' widget.
  *
@@ -24,6 +25,7 @@ use Drupal\Core\Form\FormStateInterface;
  */
 class StrawberryDefaultWidget extends StringTextareaWidget {
 
+  use MessengerTrait;
   /**
    * {@inheritdoc}
    */
@@ -38,7 +40,7 @@ class StrawberryDefaultWidget extends StringTextareaWidget {
     }
     else {
       // This should never happen since the basefield has a JSON symfony validator.
-      $this->messenger->addError(
+      $this->messenger()->addError(
         $this->t(
           'Looks like your stored field data is not in JSON format.<br> JSON says: @jsonerror <br>. Please correct it!',
           [

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -2,3 +2,8 @@ services:
     strawberryfield.keyname_manager:
         class: Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProviderManager
         parent: default_plugin_manager
+    strawberryfield_normalizer.typed_data:
+        class: \Drupal\strawberryfield\Normalizer\StrawberryfieldFieldItemNormalizer
+        tags:
+          - { name: normalizer, priority: 2 }
+        arguments: ['@entity.repository']


### PR DESCRIPTION
# FIXES

- Core Update 8.6.13 removed a trait from parent class in our widget. So add the Trait and make sure we access now the public method instead of the private property: $this->messenger()
- Individual properties of a StrawberryField (the ones we expose from the full JSON using our Key name providers plugins) are now less nested to allow Serializer/normalizer to expose the values. This still requires more work since we could be eventually (i double checked but hey, its difficult) nested arrays. I will use an iterator to fully flatten anything in case that is the case in https://github.com/esmero/strawberryfield/blob/master/src/Tools/StrawberryfieldJsonHelper.php#L86
- Stub work on adding a normalizer that will take care of the main value of a strawberryfield. This is just stub now and does nothing. But next pull will add a simple json_encode/json_decode to allow exporting and importing of this objects via REST much easier.