### PR TITLE
Make sure we have a default widget during field instance setup

### DIFF
--- a/src/Field/StrawberryFieldItemList.php
+++ b/src/Field/StrawberryFieldItemList.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\strawberryfield\Field;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Field\FieldItemList;
+
+
+/**
+ * Represents an entity field; that is, a list of StrawberrField item objects.
+ *
+ * An entity field is a list of field items, each containing a set of
+ * properties. Note that even single-valued entity fields are represented as
+ * list of field items, however for easy access to the contained item the entity
+ * field delegates __get() and __set() calls directly to the first item.
+ */
+class StrawberryFieldItemList extends FieldItemList {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function defaultValueWidget(FormStateInterface $form_state) {
+
+    // Force a non-required widget.
+    $definition = $this->getFieldDefinition();
+    $definition->setRequired(FALSE);
+    $definition->setDescription('');
+    // Force the use of our default RAW JSON strawberryField
+    $widget = \Drupal::service('plugin.manager.field.widget')->getInstance(['field_definition' => $this->getFieldDefinition()]);
+
+    $form_state->set('default_value_widget', $widget);
+
+    return $form_state->get('default_value_widget');
+  }
+
+}

--- a/src/Plugin/DataType/StrawberryKeysFromJson.php
+++ b/src/Plugin/DataType/StrawberryKeysFromJson.php
@@ -44,7 +44,7 @@ class StrawberryKeysFromJson extends ItemList {
   protected $list = [];
 
   public function getValue() {
-    if ($this->processed == NULL) {
+    if ($this->computed == FALSE) {
       $this->process();
     }
     $values = [];
@@ -56,23 +56,29 @@ class StrawberryKeysFromJson extends ItemList {
 
   public function process($langcode = NULL)
   {
-    if ($this->processed !== NULL) {
-      return $this->processed;
+    if ($this->computed == TRUE) {
+      return;
     }
     $values = [];
     $item = $this->getParent();
+    if (!empty($item->value)) {
+      // Should 10 be enough? this is json-ld not github.. so maybe...
+      $jsonArray = json_decode($item->value, TRUE, 10);
+      //@TODO deal with JSON exceptions as we have done before
 
-    // Should 10 be enough? this is json-ld not github.. so maybe...
-    $jsonArray = json_decode($item->value,true,10);
-    //@TODO deal with JSON exceptions as we have done before
-
-    $flattened = [];
-    $flattened = StrawberryfieldJsonHelper::arrayToFlatJsonPropertypaths($jsonArray);
-    $this->processed = array_keys($flattened);
-    $this->computed = TRUE;
-    foreach ($this->processed as $delta => $item) {
-      $this->list[$delta] = $this->createItem($delta, $item);
+      $flattened = [];
+      $flattened = StrawberryfieldJsonHelper::arrayToFlatJsonPropertypaths(
+        $jsonArray
+      );
+      $this->processed = array_keys($flattened);
+      $this->computed = TRUE;
+      foreach ($this->processed as $delta => $item) {
+        $this->list[$delta] = $this->createItem($delta, $item);
+      }
+    } else {
+      $this->processed = NULL;
     }
+    $this->computed = TRUE;
   }
 
   /**

--- a/src/Plugin/DataType/StrawberryKeysFromJson.php
+++ b/src/Plugin/DataType/StrawberryKeysFromJson.php
@@ -54,6 +54,10 @@ class StrawberryKeysFromJson extends ItemList {
     return $values;
   }
 
+  /**
+   * @param null $langcode
+   *
+   */
   public function process($langcode = NULL)
   {
     if ($this->computed == TRUE) {

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -19,6 +19,7 @@ use Drupal\Core\TypedData\ListDataDefinition;
  *   default_formatter = "strawberry_default_formatter",
  *   default_widget = "strawberry_textarea",
  *   constraints = {"valid_strawberry_json" = {}},
+ *   list_class = "\Drupal\strawberryfield\Field\StrawberryFieldItemList",
  *   category = "GLAM Metadata",
  * )
  */
@@ -145,9 +146,21 @@ use Drupal\Core\TypedData\ListDataDefinition;
     * {@inheritdoc}
     */
    public function isEmpty() {
-     $value = parent::isEmpty();
-     //@TODO: assume a json with only keys and no values is empty
-     return $value === NULL || $value === '';
+     // Lets optimize.
+     // All our properties are computed
+     // So if main value is empty rest will be too
+     $mainproperty = $this->mainPropertyName();
+
+     if (isset($this->{$mainproperty})) {
+       $mainvalue = $this->{$mainproperty};
+       if (empty($mainvalue) || $mainvalue == '') {
+         return TRUE;
+       }
+     }
+     else {
+       return TRUE;
+     }
+     return FALSE;
    }
 
    /**
@@ -158,6 +171,5 @@ use Drupal\Core\TypedData\ListDataDefinition;
      $values['value'] = '{"label": "' . $random->word(mt_rand(1, 2000)) . '""}';
      return $values;
    }
-
 
  }

--- a/src/Plugin/Field/FieldWidget/StrawberryDefaultWidget.php
+++ b/src/Plugin/Field/FieldWidget/StrawberryDefaultWidget.php
@@ -30,26 +30,28 @@ class StrawberryDefaultWidget extends StringTextareaWidget {
    * {@inheritdoc}
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
-
-    $rawjson = $items[$delta]->value;
-    $prettyjson = $rawjson;
-    $objectjson = json_decode($rawjson,FALSE);
-    $json_error = json_last_error();
-    if ($json_error == JSON_ERROR_NONE) {
-      $prettyjson = json_encode($objectjson, JSON_PRETTY_PRINT);
+    // Be smart, don't overprocess and empty field.
+    $prettyjson = "";
+    if (!$items[$delta]->isEmpty()) {
+      $rawjson = $items[$delta]->value;
+      $prettyjson = $rawjson;
+      $objectjson = json_decode($rawjson, FALSE);
+      $json_error = json_last_error();
+      if ($json_error == JSON_ERROR_NONE) {
+        $prettyjson = json_encode($objectjson, JSON_PRETTY_PRINT);
+      }
+      else {
+        // This should never happen since the basefield has a JSON symfony validator.
+        $this->messenger()->addError(
+          $this->t(
+            'Looks like your stored field data is not in JSON format.<br> JSON says: @jsonerror <br>. Please correct it!',
+            [
+              '@jsonerror' => json_last_error_msg()
+            ]
+          )
+        );
+      }
     }
-    else {
-      // This should never happen since the basefield has a JSON symfony validator.
-      $this->messenger()->addError(
-        $this->t(
-          'Looks like your stored field data is not in JSON format.<br> JSON says: @jsonerror <br>. Please correct it!',
-          [
-            '@jsonerror' => $json_error
-          ]
-        )
-      );
-    }
-
 
     $element['value'] = $element + [
         '#type' => 'textarea',


### PR DESCRIPTION
# FIXES

Main issue here is how Drupal 8 decides which widget to show when setting a field inside the Content Type Admin menu. There you can set default values, etc, but if a special $form_state key is not present *which can be only set via a form alter and is not used anywhere i core* if will render the widget used in the default form display to set The defaults. That is in our case totally wrong, we don't want to set a default JSON via a webform in this context (and it also does not work).

# IMPROVES
Since our StrawberryField Field uses mostly computed Properties i wanted to improve computing times. We now use much more ::computed to check instead of going into ::processed content on each property. There are tiny changes here, but it will drop a few extra cycles if the main property of the field is empty (->value) and will also be way more responsive on calculating if the field is empty which seems something Drupal does a lot.

@giancarlobi could you test this branch in any of your Archipelagos to see if everything keeps working, Solr indexing is still there and also on creating a new Object using the default Widget without any default JSON values, you see no errors?

Thanks 😄 