### PR TITLE
Implements a StrawberryField Item Normalizer 

### DIFF
--- a/src/Normalizer/StrawberryfieldFieldItemNormalizer.php
+++ b/src/Normalizer/StrawberryfieldFieldItemNormalizer.php
@@ -6,6 +6,7 @@ use Drupal\Core\Entity\EntityRepositoryInterface;
 use Drupal\serialization\Normalizer\FieldItemNormalizer;
 use Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem;
 use Drupal\serialization\Normalizer\EntityReferenceFieldItemNormalizerTrait;
+use Drupal\Core\TypedData\TypedDataInternalPropertiesHelper;
 
 /**
  * Adds the file URI to embedded file entities.
@@ -42,11 +43,17 @@ class StrawberryfieldFieldItemNormalizer extends FieldItemNormalizer {
    * {@inheritdoc}
    */
   public function normalize($field_item, $format = NULL, array $context = []) {
-    //@TODO json decode and encode into array our strawberryfield
     //@TODO check what options we can get from $context
-    $values = parent::normalize($field_item, $format, $context);
 
-
+    //@TODO allow per Field instance to limit which prop is internal or external
+    //@TODO do the inverse, a denormalizer for 'value' to allow API ingests
+    // Only do this because parent implementation can change.
+    $values = parent::normalize($field_item, $format , $context);
+    $mainproperty = $field_item->mainPropertyName();
+    // Now get the mainPropertyName and decode
+    if ((isset($values[$mainproperty])) && (!empty($values[$mainproperty])) || $values[$mainproperty]!='') {
+      $values[$mainproperty] = $this->serializer->decode($values[$mainproperty], 'json');
+    }
     return $values;
   }
 

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -4,7 +4,7 @@ namespace Drupal\strawberryfield\Plugin\Field\FieldType;
 use Drupal\Core\Field\FieldItemBase;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Field\FieldDefinitionInterface;
-use Drupal\Core\TypedData\DataDefinition;;
+use Drupal\Core\TypedData\DataDefinition;
 use Drupal\strawberryfield\Entity\keyNameProviderEntity;
 use Drupal\Component\Utility\Random;
 use Drupal\Core\TypedData\ListDataDefinition;

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -1,9 +1,9 @@
 services:
-    strawberryfield.keyname_manager:
-        class: Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProviderManager
-        parent: default_plugin_manager
-    strawberryfield_normalizer.typed_data:
-        class: \Drupal\strawberryfield\Normalizer\StrawberryfieldFieldItemNormalizer
-        tags:
-          - { name: normalizer, priority: 2 }
-        arguments: ['@entity.repository']
+  strawberryfield.keyname_manager:
+    class: Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProviderManager
+    parent: default_plugin_manager
+  serializer.normalizer.strawberryfield.typed_data:
+    class: Drupal\strawberryfield\Normalizer\StrawberryfieldFieldItemNormalizer
+    tags:
+      - { name: normalizer, priority: 100 }
+    arguments: ['@entity.repository']


### PR DESCRIPTION
# What is new ?

Related to #11  (which is almost the same but in other words)

This pull allows our JSON encoded Strawberryfield to be expanded into a full array (and then serialized as it needs to) for REST, API and in general Symfony and Drupal serialization needs. This is another step into having a fully functional strawberry seeds module. Now we can export Full Objects with all its JSON and store it in a file, expose it via REST and other build in APIs. 

# How to test

In a functional Archipelago with at least an Digital Object select one of the following options:

## Option DEV: 

enable the php devel module (removed from dev core for obvious security reasons) and run

```PHP
use Drupal\node\Entity\Node;

$serializer = \Drupal::service('serializer');
// replace Node::load(1); with any actual node id
$node = Node::load(1);
$data = $serializer->serialize($node, 'json');
dpm($data);
````
You should see something like this (i removed manually some keys to avoid 2 hour scroll)

```JSON
{
  "nid": [
    {
      "value": 1
    }
  ],
  "uuid": [
    {
      "value": "2a2d0947-fc64-4042-9a4f-3e2d5fd67adb"
    }
  ],
  "vid": [
    {
      "value": 10
    }
  ],
  "langcode": [
    {
      "value": "en"
    }
  ],
  "type": [
    {
      "target_id": "digital_object",
      "target_type": "node_type",
      "target_uuid": "76354f67-fa80-4bae-8c6f-0756dfdb6e92"
    }
  ],
  "revision_timestamp": [
    {
      "value": "2019-03-12T18:49:06+00:00",
      "format": "Y-m-d\\TH:i:sP"
    }
  ],
  "revision_uid": [
    {
      "target_id": 1,
      "target_type": "user",
      "target_uuid": "99feb0c6-45b9-4bfe-897d-6940c3257460",
      "url": "/user/1"
    }
  ],
  "revision_log": [

  ],
  "status": [
    {
      "value": true
    }
  ],
  "title": [
    {
      "value": "Test"
    }
  ],
  "uid": [
    {
      "target_id": 1,
      "target_type": "user",
      "target_uuid": "99feb0c6-45b9-4bfe-897d-6940c3257460",
      "url": "/user/1"
    }
  ],
  "created": [
    {
      "value": "2019-03-07T16:29:07+00:00",
      "format": "Y-m-d\\TH:i:sP"
    }
  ],
  "changed": [
    {
      "value": "2019-03-12T18:49:06+00:00",
      "format": "Y-m-d\\TH:i:sP"
    }
  ],
  "promote": [
    {
      "value": false
    }
  ],
  "sticky": [
    {
      "value": false
    }
  ],
  "default_langcode": [
    {
      "value": true
    }
  ],
  "revision_translation_affected": [
    {
      "value": true
    }
  ],
  "moderation_state": [
    {
      "value": "published"
    }
  ],
  "ds_switch": [

  ],
  "path": [
    {
      "alias": "/do/2a2d0947-fc64-4042-9a4f-3e2d5fd67adb",
      "pid": 121,
      "langcode": "en"
    }
  ],
  "menu_link": [

  ],
  "body": [

  ],
  "field_descriptive_metadata": [
    {
      "value": {
        "type": "Article",
        "label": "Test this",
        "owner": "Diego",
        "images": [
          1
        ],
        "as:image": {
          "s3://bae/1e0e821ba4a41ab675cf8a07603d72c9f7e5a733-en-image-1e0e821ba4a41ab675cf8a07603d72c9f7e5a733.jpg": {
            "url": "s3://bae/1e0e821ba4a41ab675cf8a07603d72c9f7e5a733-en-image-1e0e821ba4a41ab675cf8a07603d72c9f7e5a733.jpg",
            "name": "burr-mcintosh-chor.jpg",
            "type": "Image",
            "dr:fid": 1,
            "dr:for": "images",
            "dr:url": "s3://bae/1e0e821ba4a41ab675cf8a07603d72c9f7e5a733-en-image-1e0e821ba4a41ab675cf8a07603d72c9f7e5a733.jpg",
            "checksum": "bae580978ddf53e839de81545b00175c"
          }
        },
        "edm_agent": [
          {
            "name_uri": "http://www.wikidata.org/entity/Q16865199",
            "role_uri": "http://www.wikidata.org/entity/Q16869121",
            "name_label": "Burr ",
            "role_label": "proprietor "
          }
        ],
        "ismemberof": null,
        "description": "Test",
        "subject_loc": [
          {
            "uri": "http://id.loc.gov/authorities/subjects/sh2001008470",
            "label": "Metrology"
          }
        ],
        "as:generator": {
          "type": "Update",
          "actor": {
            "url": "http://localhost:8001/form/descriptive-metadata",
            "name": "descriptive_metadata",
            "type": "Service"
          },
          "endTime": "2019-03-12T14:49:07-04:00",
          "summary": "Generator",
          "@context": "https://www.w3.org/ns/activitystreams"
        },
        "local_identifier": "Diego",
        "subject_wikidata": [
          {
            "uri": "http://www.wikidata.org/entity/Q394",
            "label": "metrology "
          }
        ],
        "strawberry_field_widget_id": "descriptive_metadata",
        "strawberry_field_widget_source_entity_id": null,
        "strawberry_field_widget_source_entity_uuid": null
      },
      "str_flatten_keys": [
        "type",
        "label",
        "owner",
        "images.[*]",
        "as:image.*.url",
        "as:image.*.name",
        "as:image.*.type",
        "as:image.*.dr:fid",
        "as:image.*.dr:for",
        "as:image.*.dr:url",
        "as:image.*.checksum",
        "edm_agent.[*].name_uri",
        "edm_agent.[*].role_uri",
        "edm_agent.[*].name_label",
        "edm_agent.[*].role_label",
        "ismemberof",
        "description",
        "subject_loc.[*].uri",
        "subject_loc.[*].label",
        "as:generator.type",
        "as:generator.actor.url",
        "as:generator.actor.name",
        "as:generator.actor.type",
        "as:generator.endTime",
        "as:generator.summary",
        "as:generator.@context",
        "local_identifier",
        "subject_wikidata.[*].uri",
        "subject_wikidata.[*].label",
        "strawberry_field_widget_id",
        "strawberry_field_widget_source_entity_id",
        "strawberry_field_widget_source_entity_uuid"
      ],
      "type": [
        "Article",
        "Image",
        "Update",
        "Service"
      ],
      "typicalAgeRange": [

      ],
      "url": [
        "s3://bae/1e0e821ba4a41ab675cf8a07603d72c9f7e5a733-en-image-1e0e821ba4a41ab675cf8a07603d72c9f7e5a733.jpg",
        "http://localhost:8001/form/descriptive-metadata"
      ],
      "version": [

      ],
      "video": [

      ],
      "workExample": [

      ],
      "workTranslation": [

      ]
    }
  ]
}
````


You will see a beautiful JSON and a *lot* of Schema.org properties. All the hierarchies of a RAW strawberryfield (look for 'value' inside field_descriptive_metadata) but also the computed ones! Which we will be able to selectively hide or expose (WIP).

## Option REST: 

On a vanilla Archipelago Docker deployment REST UI is not installed. Run  
```SHELL
docker exec -ti esmero-web bash -c "composer require drupal/restui"
```
and enable the module. Go to http://localhost:8001/admin/config/services/rest/resource/entity%3Anode/edit

Now enable JSON format, only the 'GET' method and for authentication use cookie (this is just a test, don't think this is production config). Save. 

Since you are logged in, go to and object URL like : `http://localhost:8001/do/1d4aae51-c06b-402c-8bba-9094c0b792f3?_format=json` with **emphasis** on adding `_format=json` to any Object URL, your URL will be different of course, the magic of UUIDs.

if you don't follow the instructions you will be very miserable and will additionally see
```
{"message":"Not acceptable format: json"}
```

If you follow them, you have Object a hierarchical Object as Data. Not Flat, not FLAT. Hierarchical!. And also Flat. This is great.

Side note: took more time to write this explanation that actual code it.


# What is next

- We need the denormalizer and a Value Constructor. If someone sends or deposits and Object, we need to transform Strawberryfield back into a String and also discard computed values
- We need to allow Super users to define which properties they want to expose. Simply add that to our JSON KEY provider plugin options
- Now we can build better serializers and implemente all the goodies of our Metadata Display engine into REST

@giancarlobi would love a second set of eyes here. 


