### PR TITLE
Provide Event driven reactions to Strawberry Bearing Content Entities

### DIFF
--- a/src/Event/StrawberryfieldCrudEvent.php
+++ b/src/Event/StrawberryfieldCrudEvent.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\strawberryfield\Event;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class to contain a SBF bearing entity event.
+ */
+class StrawberryfieldCrudEvent extends Event {
+
+  /**
+   * The Entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  private $entity;
+
+  /**
+   * The SBF field machine names.
+   *
+   * @array;
+   */
+  private $fields;
+
+  /**
+   * The event type.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldEventType
+   */
+  private $eventType;
+
+  /**
+   * Construct a new entity event.
+   *
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity which caused the event.
+   */
+  public function __construct($event_type, EntityInterface $entity, array $sbfFields) {
+    $this->entity = $entity;
+    $this->eventType = $event_type;
+    $this->fields =  $sbfFields;
+  }
+
+  /**
+   * Method to get the entity from the event.
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+  /**
+   * Method to get the fields from the event.
+   */
+  public function getFields() {
+    return $this->fields;
+  }
+
+  /**
+   * Method to get the event type.
+   */
+  public function getEventType() {
+    return $this->eventType;
+  }
+
+}

--- a/src/Event/StrawberryfieldFlavourCrudEvent.php
+++ b/src/Event/StrawberryfieldFlavourCrudEvent.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Drupal\strawberryfield\Event;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class to contain a SBF bearing entity flavour event.
+ *
+ * @TODO flesh this one out once we have flavour processors.
+ */
+class StrawberryfieldFlavourCrudEvent extends Event {
+
+  /**
+   * The Source Entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  private $entity;
+
+  /**
+   * The SBF fields.
+   *
+   * @var \Drupal\Core\Field\FieldItemListInterface;
+   */
+  private $fields;
+
+  /**
+   * The event type.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldEventType
+   */
+  private $eventType;
+
+  /**
+   * Construct a new entity event.
+   *
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity which caused the event.
+   */
+  public function __construct($event_type, EntityInterface $entity, FieldItemListInterface $fields) {
+    $this->entity = $entity;
+    $this->eventType = $event_type;
+    $this->fields = $fields;
+  }
+
+  /**
+   * Method to get the entity from the event.
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+  /**
+   * Method to get the fields from the event.
+   */
+  public function getFields() {
+    return $this->fields;
+  }
+
+  /**
+   * Method to get the event type.
+   */
+  public function getEventType() {
+    return $this->eventType;
+  }
+
+}

--- a/src/Event/StrawberryfieldJsonProcessEvent.php
+++ b/src/Event/StrawberryfieldJsonProcessEvent.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Drupal\strawberryfield\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class to contain a SBF JSON processing event.
+ */
+class StrawberryfieldJsonProcessEvent extends Event {
+
+  /**
+   * The RAW JSON
+   *
+   * Should hopefully never modified during an Event life clycle
+   *
+   * @var array
+   */
+  protected $originalJson;
+
+  /**
+   * a processed JSON
+   *
+   * This is where all changes happen and event subscribers are encourage to
+   * deal with changing, adding, filtering it.
+   *
+   * @var array
+   */
+  private $processedJson;
+
+  /**
+   * The event type.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldEventType
+   */
+  private $eventType;
+
+  /**
+   * If processed JSON was modified since the Event was dispatched.
+   *
+   * @var boolean
+   */
+  private $modified = FALSE;
+
+
+  /**
+   * Construct a new Json processing event.
+   *
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity which caused the event.
+   */
+  public function __construct($event_type, array $originalJson, array $processedJson) {
+    $this->eventType = $event_type;
+    $this->originalJson = $originalJson;
+    $this->processedJson = $processedJson;
+  }
+
+  /**
+   * Method to get the Processed JSON from the event.
+   */
+  public function getProcessedJson() {
+    return $this->processedjson;
+  }
+
+
+  /**
+   * Method to set the Processed JSON back to the event.
+   */
+  public function setProcessedJson(array $modifiedjson) : void {
+    if ($modifiedjson!== $this->processedjson) {
+      $this->processedjson = $modifiedjson;
+      $this->setModified(TRUE);
+    }
+  }
+
+  /**
+   * @param bool $modified
+   *
+   * Invoked internally when setting a different processed JSON
+   */
+  private function setModified(bool $modified): void {
+    $this->modified = $modified;
+  }
+
+  /**
+   * @return bool
+   */
+  public function wasModified(): bool {
+    return $this->modified;
+  }
+
+  /**
+   * Method to get the fields from the event.
+   */
+  public function getOriginalJson() {
+    return $this->originalJson;
+  }
+
+  /**
+   * Method to get the event type.
+   */
+  public function getEventType() {
+    return $this->eventType;
+  }
+
+}

--- a/src/Event/StrawberryfieldServiceEvent.php
+++ b/src/Event/StrawberryfieldServiceEvent.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Drupal\strawberryfield\Event;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class to contain a SBF Service event.
+ */
+class StrawberryfieldServiceEvent extends Event {
+
+  /**
+   * The Entity.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface
+   */
+  private $entity;
+
+  /**
+   * The SBF field with that contains the service.
+   *
+   * @var \Drupal\Core\Field\FieldItemInterface;
+   */
+  private $field;
+
+  /**
+   * The Service definition.
+   *
+   * @array;
+   */
+  private $service;
+
+  /**
+   * The event type.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldEventType
+   */
+  private $eventType;
+
+  /**
+   * Construct a new entity event.
+   *
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity which caused the event.
+   */
+  public function __construct($event_type, EntityInterface $entity, FieldItemListInterface $field, array $service) {
+    $this->entity = $entity;
+    $this->eventType = $event_type;
+    $this->field = $field;
+    $this->service = $service;
+  }
+
+  /**
+   * Method to get the entity from the event.
+   */
+  public function getEntity() {
+    return $this->entity;
+  }
+
+  /**
+   * Method to get the fields from the event.
+   */
+  public function getField() {
+    return $this->field;
+  }
+
+  /**
+   * Method to get the service.
+   */
+  public function getService() {
+    return $this->service;
+  }
+  /**
+   * Method to get the event type.
+   */
+  public function getEventType() {
+    return $this->eventType;
+  }
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventDeleteSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventDeleteSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventDeleteSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::DELETE][] = ['onEntityDelete', 100];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *   The event.
+   */
+  abstract public function onEntityDelete(StrawberryfieldCrudEvent $event);
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventDeleterevisionSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventDeleterevisionSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventDeleterevisionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::DELETE_REVISION][] = ['onEntityDeleterevision', 100];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *   The event.
+   */
+  abstract public function onEntityDeleterevision(StrawberryfieldCrudEvent $event);
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventInsertSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventInsertSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventInsertSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::INSERT][] = ['onEntityInsert', 100];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *   The event.
+   */
+  abstract public function onEntityInsert(StrawberryfieldCrudEvent $event);
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventInvokeServiceSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventInvokeServiceSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldServiceEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventInvokeServiceSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::INVOKE_SERVICE][] = ['onEntityInvokeService', 100];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldServiceEvent $event
+   *   The event.
+   */
+  abstract public function onEntityInvokeService(StrawberryfieldServiceEvent $event);
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventJsonProcessingSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventJsonProcessingSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldServiceEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventJsonProcessingSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::JSONPROCESS][] = ['onJsonInvokeProcess', 100];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldServiceEvent $event
+   *   The event.
+   */
+  abstract public function onJsonInvokeProcess(StrawberryfieldServiceEvent $event);
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventNewrevisionSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventNewrevisionSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventNewrevisionSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::NEW_REVISION][] = ['onEntityNewrevision', 100];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *   The event.
+   */
+  abstract public function onEntityNewrevision(StrawberryfieldCrudEvent $event);
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventPresaveSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @var int
+   */
+  protected static $priority = -800;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // Make sure we have access before everything else here since we want
+    // Enrich our JSON before anything runs.
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::PRESAVE][] = ['onEntityPresave', self::$priority];
+    return $events;
+  }
+
+
+    /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *   The event.
+   */
+  abstract public function onEntityPresave(StrawberryfieldCrudEvent $event);
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use CachingIterator;
+use ArrayIterator;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+class StrawberryfieldEventPresaveSubscriberVocabCreator extends StrawberryfieldEventPresaveSubscriber {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var int
+   */
+  protected static $priority = -700;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+
+  /**
+   * Constructs a new StrawberryfieldEventPresaveSubscriberVocabCreator.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger.
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+  }
+
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function onEntityPresave(StrawberryfieldCrudEvent $event) {
+    dpm($event);
+    /* @var $entity \Drupal\Core\Entity\ContentEntityInterface */
+    $entity = $event->getEntity();
+    $sbf_fields = $event->getFields();
+    $newlycreatedcount = 0;
+    foreach ($sbf_fields as $field_name) {
+      /* @var $field \Drupal\Core\Field\FieldItemInterface */
+      $field = $entity->get($field_name);
+      if (!$field->isEmpty()) {
+        $jsonkeys = [];
+        $jsonkeys = $field->{'str_flatten_keys'};
+        foreach ($jsonkeys as $path) {
+          // Since our keys will be jsonpaths, we can explode them first by dot
+          $path_parts_raw = [];
+          $path_parts_raw = explode(".", $path);
+          $terms = [];
+          $terms = new CachingIterator(
+            new ArrayIterator($path_parts_raw)
+          );
+          $term_path = [];
+          foreach ($terms as $json_node) {
+            if ($terms->hasNext()) {
+              $next = $terms->getInnerIterator()->current();
+              if ($next == '[*]' || $next == '*') {
+                $term_path[] = $json_node . "." . $next;
+                continue;
+              }
+            }
+            if ($json_node != '[*]' && $json_node != '*') {
+              $term_path[] = $json_node;
+            }
+            $parent_id = 0;
+            $term_path = array_filter($term_path);
+            $breadcrumb = '';
+            foreach ($term_path as $path) {
+              $breadcrumb = empty($breadcrumb) ? $path : $breadcrumb . '.' . $path;
+              $query = \Drupal::entityQuery('taxonomy_term');
+              $query->condition('vid', "strawberryfield_voc_id");
+              $query->condition('name', $path);
+              $query->condition('parent', $parent_id, 'IN');
+              $tids = $query->execute();
+              if (count($tids) == 0) {
+                $new_term = \Drupal\taxonomy\Entity\Term::create(
+                  [
+                    'vid' => 'strawberryfield_voc_id',
+                    'name' => $path,
+                    'parent' => $parent_id,
+                    'field_jsonpath' => $breadcrumb,
+                  ]
+                );
+                $newlycreatedcount++;
+                $new_term->enforceIsNew();
+                $new_term->save();
+                $parent_id = $new_term->id();
+              }
+              else {
+                //Assuming parent is there
+                foreach ($tids as $terms_id) {
+                  $parent_id = $terms_id;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    if ($newlycreatedcount > 0) {
+      $this->messenger->addStatus(t('New Terms added to the vocabulary'));
+    }
+  }
+}

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
@@ -54,7 +54,7 @@ class StrawberryfieldEventPresaveSubscriberVocabCreator extends StrawberryfieldE
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function onEntityPresave(StrawberryfieldCrudEvent $event) {
-    dpm($event);
+
     /* @var $entity \Drupal\Core\Entity\ContentEntityInterface */
     $entity = $event->getEntity();
     $sbf_fields = $event->getFields();

--- a/src/EventSubscriber/StrawberryfieldEventSaveSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventSaveSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+abstract class StrawberryfieldEventSaveSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    // @TODO check event priority and adapt to future D9 needs.
+    $events[StrawberryfieldEventType::SAVE][] = ['onEntitySave', 100];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *   The event.
+   */
+  abstract public function onEntitySave(StrawberryfieldCrudEvent $event);
+
+}

--- a/src/StrawberryfieldEventType.php
+++ b/src/StrawberryfieldEventType.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 5/3/19
+ * Time: 4:14 PM
+ */
+
+namespace Drupal\strawberryfield;
+
+
+final class StrawberryfieldEventType {
+  /**
+   * Name of the event fired when pre saving an node with a SBF attached.
+   *
+   * This event allows modules to perform an action whenever a node
+   * with a SBF(Strawberry Field) is saved. The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   *
+   * See \strawberryfield_node_presave
+   *
+   * @Event
+   *
+   * @see strawberryfield_node_presave
+   *
+   * @var string
+   */
+  const PRESAVE = 'sbf.node.presave';
+
+  /**
+   * Name of the event fired when inserting a new node with a SBF attached.
+   *
+   * This event allows modules to perform an action whenever a node
+   * with a SBF(Strawberry Field) is inserted for the first time.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   *
+   * See \strawberryfield_node_insert
+   *
+   * @Event
+   *
+   * @see strawberryfield_node_insert
+   *
+   * @var string
+   */
+  const INSERT = 'sbf.node.insert';
+
+  /**
+   * Name of the event fired when updating a node with a SBF attached.
+   *
+   * This event allows modules to perform an action whenever a node
+   * with a SBF(Strawberry Field) is updated.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   *
+   * See \strawberryfield_node_update
+   *
+   * @Event
+   *
+   * @see strawberryfield_node_update
+   *
+   * @var string
+   */
+  const SAVE = 'sbf.node.save';
+
+  /**
+   * Name of the event fired when revisioning a node with a SBF attached.
+   *
+   * This event allows modules to perform an action whenever a node
+   * with a SBF(Strawberry Field) gets a new revision inserted.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   *
+   * See \strawberryfield_node_update
+   *
+   * @Event
+   *
+   * @see strawberryfield_node_update
+   *
+   * @var string
+   */
+  const NEW_REVISION = 'sbf.node.newrevision';
+
+  /**
+   * Name of the event fired when a node revision with SBF attached is deleted.
+   *
+   * This event allows modules to perform an action whenever a node
+   * with a SBF(Strawberry Field) gets a new revision inserted.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   *
+   * See \strawberryfield_node_revision_delete
+   *
+   * @Event
+   *
+   * @see strawberryfield_node_revision_delete
+   *
+   * @var string
+   */
+  const DELETE_REVISION = 'sbf.node.deleterevision';
+
+  /**
+   * Name of the event fired when a node with SBF attached is deleted.
+   *
+   * This event allows modules to perform an action whenever a node
+   * with a SBF(Strawberry Field) gets deleted
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   *
+   * See \strawberryfield_node_delete
+   *
+   * @Event
+   *
+   * @see strawberryfield_node_delete
+   *
+   * @var string
+   */
+  const DELETE = 'sbf.node.delete';
+
+  /**
+   * Name of the event fired when a SBF JSON needs to be processed
+   *
+   * This event allows modules to perform an action whenever a SBF
+   * JSON needs to be enriched, cleaned and or normalized.
+   * This is the state of the JSON just before being saved.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldServiceEvent instance.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const JSONPROCESS = 'sbf.json.process';
+
+  /**
+   * Name of the event fired when invoking SBF JSON "Seasoners"
+   *
+   * This event allows modules to perform an action whenever invoking SBF
+   * JSON Seasoners, a.k.a embeded Services.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldServiceEvent instance.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const INVOKE_SERVICE = 'sbf.json.invokeservice';
+
+  /**
+   * Name of the event fired when inserting a SBF JSON Flavour
+   *
+   * This event allows modules to perform an action whenever a new JSON Flavour
+   * is generated.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldFlavourCrudEvent instance.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const INSERT_FLAVOUR = 'sbf.flavour.insert';
+
+  /**
+   * Name of the event fired when deleting a SBF JSON Flavour
+   *
+   * This event allows modules to perform an action whenever a JSON Flavour
+   * is deleted.
+   * The event listener method receives a
+   * \Drupal\strawberryfield\StrawberryfieldFlavourCrudEvent instance.
+   *
+   * @Event
+   *
+   * @var string
+   */
+  const DELETE_FLAVOUR = 'sbf.flavour.delete';
+
+
+
+}

--- a/src/StrawberryfieldEventType.php
+++ b/src/StrawberryfieldEventType.php
@@ -23,7 +23,7 @@ final class StrawberryfieldEventType {
    *
    * @see strawberryfield_node_presave
    * @see \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent
-   *
+   * @see \Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberVocabCreator
    *
    * @var string
    */
@@ -186,7 +186,4 @@ final class StrawberryfieldEventType {
    * @var string
    */
   const DELETE_FLAVOUR = 'sbf.flavour.delete';
-
-
-
 }

--- a/src/StrawberryfieldEventType.php
+++ b/src/StrawberryfieldEventType.php
@@ -15,13 +15,15 @@ final class StrawberryfieldEventType {
    *
    * This event allows modules to perform an action whenever a node
    * with a SBF(Strawberry Field) is saved. The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent instance.
    *
    * See \strawberryfield_node_presave
    *
    * @Event
    *
    * @see strawberryfield_node_presave
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent
+   *
    *
    * @var string
    */
@@ -33,13 +35,14 @@ final class StrawberryfieldEventType {
    * This event allows modules to perform an action whenever a node
    * with a SBF(Strawberry Field) is inserted for the first time.
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent instance.
    *
    * See \strawberryfield_node_insert
    *
    * @Event
    *
    * @see strawberryfield_node_insert
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent
    *
    * @var string
    */
@@ -51,13 +54,14 @@ final class StrawberryfieldEventType {
    * This event allows modules to perform an action whenever a node
    * with a SBF(Strawberry Field) is updated.
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent instance.
    *
    * See \strawberryfield_node_update
    *
    * @Event
    *
-   * @see strawberryfield_node_update
+   * @see
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent
    *
    * @var string
    */
@@ -69,13 +73,14 @@ final class StrawberryfieldEventType {
    * This event allows modules to perform an action whenever a node
    * with a SBF(Strawberry Field) gets a new revision inserted.
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent instance.
    *
-   * See \strawberryfield_node_update
+   * See \strawberryfield_node_revision_create
    *
    * @Event
    *
    * @see strawberryfield_node_update
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent
    *
    * @var string
    */
@@ -87,13 +92,14 @@ final class StrawberryfieldEventType {
    * This event allows modules to perform an action whenever a node
    * with a SBF(Strawberry Field) gets a new revision inserted.
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent instance.
    *
    * See \strawberryfield_node_revision_delete
    *
    * @Event
    *
    * @see strawberryfield_node_revision_delete
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent
    *
    * @var string
    */
@@ -105,13 +111,14 @@ final class StrawberryfieldEventType {
    * This event allows modules to perform an action whenever a node
    * with a SBF(Strawberry Field) gets deleted
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent instance.
    *
    * See \strawberryfield_node_delete
    *
    * @Event
    *
    * @see strawberryfield_node_delete
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent
    *
    * @var string
    */
@@ -124,9 +131,11 @@ final class StrawberryfieldEventType {
    * JSON needs to be enriched, cleaned and or normalized.
    * This is the state of the JSON just before being saved.
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldServiceEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldJsonProcessEvent instance.
    *
    * @Event
+   *
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldJsonProcessEvent
    *
    * @var string
    */
@@ -152,9 +161,11 @@ final class StrawberryfieldEventType {
    * This event allows modules to perform an action whenever a new JSON Flavour
    * is generated.
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldFlavourCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldFlavourCrudEvent instance.
    *
    * @Event
+   *
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldFlavourCrudEvent
    *
    * @var string
    */
@@ -166,9 +177,11 @@ final class StrawberryfieldEventType {
    * This event allows modules to perform an action whenever a JSON Flavour
    * is deleted.
    * The event listener method receives a
-   * \Drupal\strawberryfield\StrawberryfieldFlavourCrudEvent instance.
+   * \Drupal\strawberryfield\Event\StrawberryfieldFlavourCrudEvent instance.
    *
    * @Event
+   *
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldFlavourCrudEvent
    *
    * @var string
    */

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -4,9 +4,10 @@
  * Contains strawberryfield.module.
  */
 
-use Drupal\Core\Cache\Cache;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Drupal\strawberryfield\StrawberryfieldEventType;
 
 
 /**
@@ -31,7 +32,6 @@ function strawberryfield_invalidate_fieldefinition_caches(NodeInterface $node) {
     $needscleaning = FALSE;
     $strawberry_field_class = $class = \Drupal::service('plugin.manager.field.field_type')->getPluginClass('strawberryfield_field');
     foreach ($node->getFieldDefinitions() as $field) {
-      $field_name = $field->getName();
       $class = $field->getItemDefinition()->getClass();
       $is_ripe = ($class === $strawberry_field_class) || is_subclass_of(
           $class,
@@ -49,120 +49,46 @@ function strawberryfield_invalidate_fieldefinition_caches(NodeInterface $node) {
   }
 }
 
+/**
+ * Implements hook_node_presave().
+ *
+ * {@inheritdoc}
+ */
 function strawberryfield_node_presave(ContentEntityInterface $entity) {
 
-  $field_item_lists = $entity->getFields();
-  $newlycreatedcount = 0;
-  //@TODO refactor this as part of the AS/event driven architecture
-  // And make all this efforts JSON based plugins.
-  foreach ($field_item_lists as $field)
-    $type = $field->getFieldDefinition()->getType();
-  if ($type == 'strawberryfield_field') {
-    if (!$field->isEmpty) {
-      $jsonkeys = [];
-      $jsonkeys = $field->{'str_flatten_keys'};
-      foreach ($jsonkeys as $path) {
-        // Since our keys will be jsonpaths, we can explode them first by dot
-        $path_parts_raw = [];
-        $path_parts_raw = explode(".", $path);
-        $terms = [];
-        $terms = new CachingIterator(
-          new ArrayIterator($path_parts_raw)
-        );
-        $term_path = [];
-        foreach ($terms as $json_node) {
-          if ($terms->hasNext()) {
-            $next = $terms->getInnerIterator()->current();
-            if ($next == '[*]' || $next == '*') {
-              $term_path[] = $json_node . "." . $next;
-              continue;
-            }
-          }
-          if ($json_node != '[*]' && $json_node != '*') {
-            $term_path[] = $json_node;
-          }
-          $parent_id = 0;
-          $term_path = array_filter($term_path);
-          $breadcrumb = '';
-          foreach ($term_path as $path) {
-            $breadcrumb = empty($breadcrumb)? $path: $breadcrumb.'.'.$path;
-            $query = \Drupal::entityQuery('taxonomy_term');
-            $query->condition('vid', "strawberryfield_voc_id");
-            $query->condition('name', $path);
-            $query->condition('parent', $parent_id, 'IN');
-            $tids = $query->execute();
-            if (count($tids) == 0) {
-              $new_term = \Drupal\taxonomy\Entity\Term::create(
-                [
-                  'vid' => 'strawberryfield_voc_id',
-                  'name' => $path,
-                  'parent' => $parent_id,
-                  'field_jsonpath' => $breadcrumb,
-                ]
-              );
-              $newlycreatedcount++;
-              $new_term->enforceIsNew();
-              $new_term->save();
-              $parent_id = $new_term->id();
-            }
-            else {
-              //Assuming parent is there
-              foreach ($tids as $terms_id) {
-                $parent_id = $terms_id;
-              }
-            }
+  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
+    $event_type = StrawberryfieldEventType::PRESAVE;
+    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher->dispatch($event_type, $event);
+  }
 
-          }
-        }
+}
+
+/**
+ * Checks if Content entity bears SBF and if so returns machine names
+ *
+ * This function statically caches per Bundle and entity type the results.
+ *
+ * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+ *
+ * @return array
+ *  Returns a numberic keyed array with machine names for the SBF fields
+ */
+function strawberryfield_bears_strawberryfield(ContentEntityInterface $entity) {
+  $hassbf = &drupal_static(__FUNCTION__);
+  $entitytype = $entity->getEntityTypeId();
+  $bundle = $entity->bundle();
+  $key = $entitytype . ":" . $bundle;
+  if (!isset($hassbf[$key])) {
+    $hassbf[$key] = [];
+    $field_item_lists = $entity->getFields();
+    foreach ($field_item_lists as $field) {
+      if ($field->getFieldDefinition()->getType() == 'strawberryfield_field') {
+        $hassbf[$key][] = $field->getFieldDefinition()->getName();
       }
-    if ($newlycreatedcount > 0) {
-      \Drupal::messenger()->addStatus(t('New Terms added to the vocabulary'));
-    }
-
     }
   }
+  return $hassbf[$key];
 }
-
-/**
- * Implements hook_entity_base_field_info().
-
-function strawberryfield_field_entity_base_field_info(EntityTypeInterface $entity_type) {
-  $fields = [];
-  if ($entity_types = _strawberryfieldable_get_entity_types()) {
-    // Adding field to entity types.
-    if (in_array($entity_type->id(), $entity_types)) {
-      $fields['strawberryfield_entityreferences'] = BaseFieldDefinition::create('entity_reference')
-        ->setName('strawberryfield_entityreferences')
-        ->setTargetEntityTypeId($entity_type->id())
-        ->setSetting('target_type', 'group_content')
-        ->setLabel(t('Related to'))
-        ->setTranslatable(FALSE)
-        ->setComputed(TRUE)
-        ->setCustomStorage(TRUE)
-        ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
-        ->setClass('\Drupal\gcontent_field\Field\GcontentFieldItemList')
-        ->setDisplayConfigurable('form', TRUE)
-        ->setDisplayConfigurable('view', TRUE)
-        ->setDisplayOptions('view', [
-          'label' => 'hidden',
-          'type' => 'hidden',
-          'weight' => 50,
-        ]);
-    }
-  }
-  return $fields;
-}
-
-/**
- * Get entities where the field should be added.
-
-function _strawberryfieldable_get_entity_types() {
-  $entity_types = [];
-  $field_map = \Drupal::entityManager()->getFieldMap();
-  foreach ($field_map['node'] as $field => $usage) {
-    if ($usage['type'] == "strawberryfield_field")
-      $entity_types = $entity_types + $usage['bundles'];
-  }
-}
-return $entity_types;
-} */

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -9,14 +9,106 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
 use Drupal\strawberryfield\StrawberryfieldEventType;
 
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * {@inheritdoc}
+ */
+function strawberryfield_node_presave(ContentEntityInterface $entity) {
+
+  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
+    $event_type = StrawberryfieldEventType::PRESAVE;
+    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher->dispatch($event_type, $event);
+  }
+
+}
 
 /**
- * Implements hook_node_insert().
+ * Implements hook_ENTITY_TYPE_update().
  *
- * @param \Drupal\node\NodeInterface $node
+ * {@inheritdoc}
  */
-function strawberryfield_node_insert(NodeInterface $node) {
-  strawberryfield_invalidate_fieldefinition_caches($node);
+function strawberryfield_node_update(ContentEntityInterface $entity) {
+
+  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
+    $event_type = StrawberryfieldEventType::SAVE;
+    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher->dispatch($event_type, $event);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ *
+ * {@inheritdoc}
+ */
+function strawberryfield_node_insert(ContentEntityInterface $entity) {
+
+  //@TODO move this to an event subscriber.
+  strawberryfield_invalidate_fieldefinition_caches($entity);
+
+  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
+    $event_type = StrawberryfieldEventType::INSERT;
+    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher->dispatch($event_type, $event);
+  }
+}
+/**
+ * Implements hook_ENTITY_TYPE_revision_create().
+ *
+ * {@inheritdoc}
+ */
+function strawberryfield_node_revision_create(ContentEntityInterface $new_revision, ContentEntityInterface $entity, $keep_untranslatable_fields) {
+
+  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
+    $event_type = StrawberryfieldEventType::NEW_REVISION;
+    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher->dispatch($event_type, $event);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ *
+ * {@inheritdoc}
+ */
+function strawberryfield_node_delete(ContentEntityInterface $entity) {
+
+  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
+    $event_type = StrawberryfieldEventType::DELETE;
+    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher->dispatch($event_type, $event);
+  }
+
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_revision_delete().
+ *
+ * {@inheritdoc}
+ */
+function strawberryfield_node_revision_delete(ContentEntityInterface $entity) {
+
+  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
+    $event_type = StrawberryfieldEventType::DELETE;
+    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
+    $dispatcher = \Drupal::service('event_dispatcher');
+    $dispatcher->dispatch($event_type, $event);
+  }
+  //@TODO move this to an event subscriber.
+  strawberryfield_invalidate_fieldefinition_caches($entity);
 }
 
 
@@ -25,13 +117,13 @@ function strawberryfield_node_insert(NodeInterface $node) {
  *
  * @param \Drupal\node\NodeInterface $node
  */
-function strawberryfield_invalidate_fieldefinition_caches(NodeInterface $node) {
+function strawberryfield_invalidate_fieldefinition_caches(ContentEntityInterface $entity) {
 
   //@TODO do the same for StrawberryfieldKeyNameProvider Plugins
-  if ($node->isPublished() && $node->isDefaultRevision()) {
+  if ($entity->isPublished() && $entity->isDefaultRevision()) {
     $needscleaning = FALSE;
     $strawberry_field_class = $class = \Drupal::service('plugin.manager.field.field_type')->getPluginClass('strawberryfield_field');
-    foreach ($node->getFieldDefinitions() as $field) {
+    foreach ($entity->getFieldDefinitions() as $field) {
       $class = $field->getItemDefinition()->getClass();
       $is_ripe = ($class === $strawberry_field_class) || is_subclass_of(
           $class,
@@ -49,22 +141,6 @@ function strawberryfield_invalidate_fieldefinition_caches(NodeInterface $node) {
   }
 }
 
-/**
- * Implements hook_node_presave().
- *
- * {@inheritdoc}
- */
-function strawberryfield_node_presave(ContentEntityInterface $entity) {
-
-  if ($sbf_fields = strawberryfield_bears_strawberryfield($entity)) {
-    $event_type = StrawberryfieldEventType::PRESAVE;
-    $event = new StrawberryfieldCrudEvent($event_type, $entity, $sbf_fields);
-    /** @var \Symfony\Component\EventDispatcher\EventDispatcher $dispatcher */
-    $dispatcher = \Drupal::service('event_dispatcher');
-    $dispatcher->dispatch($event_type, $event);
-  }
-
-}
 
 /**
  * Checks if Content entity bears SBF and if so returns machine names

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -7,3 +7,8 @@ services:
     tags:
       - { name: normalizer, priority: 100 }
     arguments: ['@entity.repository']
+  strawberryfield.presavevocab_subscriber:
+    class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberVocabCreator
+    tags:
+      - {name: event_subscriber}
+    arguments: ['@string_translation', '@messenger']


### PR DESCRIPTION
# What is new

To allow for much more control on how the JSON's lifecycle inside a StrawberryField happens, from its conception either via Webforms, direct JSON editing (manual) or API we decided to address some of our many `@TODOS` regarding an event driven architecture and allowed SBF to define events, dispatch them and set the basic abstract classes from which listeners to those events can be extended and built on.

There is a tiny little bit of performance improvement here too, since we cache statically now which Bundles bear Strawberry fields before dispatching the events and pass the machine name of those fields to the event itself.  Function which could be called many times in a batch ingest process will keep its results around during a single process and make also dispatching events much more safer.

# NOTE

Don't merge yet. No need to test until all commits are there. This is the first of a series of commits that will build this pull, all  needed to address correctly https://github.com/esmero/format_strawberryfield/issues/11  and also needed to move some heavy JSON and file entity lifting from https://github.com/esmero/webform_strawberryfield/. Basically we will move some Webform handler logic to an EventSubscriber and deal with marking which JSON keys refer to entities (files, nodes, etc) in a way more generic way, also moving away from storing Drupal IDs  to storing internal links to the actual entities (smart!). This will make our content totally portable between Drupal's and much easier to ingest.

@giancarlobi will let you know when i'm there and ready for testing