### PR TITLE
Refactor StrawberryfieldFlavorDatasource to allow Node bundles

### DIFF
--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -4,6 +4,8 @@ namespace Drupal\strawberryfield\TypedData;
 
 use Drupal\Core\TypedData\ComplexDataDefinitionBase;
 use Drupal\Core\TypedData\DataDefinition;
+use Drupal\Core\TypedData\DataReferenceTargetDefinition;
+use Drupal\Core\Entity\TypedData\EntityDataDefinition;
 
 /**
  * A typed data definition class for describing widgets.
@@ -18,7 +20,8 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
 
       $info = &$this->propertyDefinitions;
       $info['page_id'] = DataDefinition::create('string')->setLabel('Page ID');
-      $info['parent_id'] = DataDefinition::create('string')->setLabel('Parent ID');
+      $info['parent_id'] = DataReferenceTargetDefinition::create('integer');
+      $info['target_id'] = EntityDataDefinition::create('node')->setLabel('Parent Node ID');
       $info['fulltext'] = DataDefinition::create('string')->setLabel('FullText test');
       //§/ required by Content Access processor , maybe we can disable it in some manner
       $info['status'] = DataDefinition::create('boolean')->setLabel('Status');


### PR DESCRIPTION
This pull brings some small changes, but it looks like a lot because of the removed lines and some shifting lines done because of the Dependency injection.

1. Adds a configuration form
2. Adds ::getApplicableBundlesWithSbfField() which filters for node bundles  that have a SBF field type field
3. Makes ::getBundles aware of getApplicableBundlesWithSbfField
4. Injects some services from the Main container in the ::create method

@giancarlobi please look at this and let me know if this works. I will be adding more code during the day to the same pull, and you can of course do the same (or request changes, etc)

looking at how much code we are duplicating from `\Drupal\search_api\Plugin\search_api\datasource\ContentEntity` maybe we should think in the near future to extend that class instead of `DatasourcePluginBase`. That way we need to only override the methods we have in particular, or even reuse some of them and then refine. (like calling the $parent for some functions as input for our own)

Also, we need to change the primary key of our ComplexData type, right now its
```PHP
$data = [
        'page_id' => $splitted_id[1],
````

but that means that for every first page of every node, the page_id will be the same. Maybe we need and extra key, the full $item_id and use that for ?

```public function getItemId(ComplexDataInterface $item) {```
 
So, instead of 
```PHP
    $values = $item->get('page_id')->getValue();
    return $values ?: NULL;
```
We have 
```PHP
  $values = $item->get('item_id')->getValue();
   return $values ?: NULL;
````

Ideas?