### PR TITLE
Fully functional parent Node indexing!

### DIFF
--- a/src/Annotation/StrawberryfieldKeyNameProvider.php
+++ b/src/Annotation/StrawberryfieldKeyNameProvider.php
@@ -13,7 +13,7 @@ use Drupal\Core\Annotation\Translation;
 /**
  * Defines a StrawberryfieldKeyNameProvider item annotation object.
  *
- * Class StrawberryfieldKeyNameProviderAnnotation
+ * Class StrawberryfieldKeyNameProvider
  *
  * @package Drupal\strawberryfield\Annotation
  *

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -549,7 +549,7 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements Pl
       $data = [
         'item_id' => $id,
         'page_id' => $splitted_id[1],
-        'target_id' => EntityAdapter::createFromEntity($this->entityTypeManager->getStorage('node')->load($splitted_id[0])),
+        'target_id' => $splitted_id[0],
         'parent_id' => $splitted_id[0],
         'fulltext' => 'Start ' . $splitted_id[1] . ' End',
       ];

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -21,9 +21,8 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
 
       $info = &$this->propertyDefinitions;
       $info['item_id'] = DataDefinition::create('string')->setLabel('Item ID');
-      $info['page_id'] = DataDefinition::create('string')->setLabel('Page ID');
+      $info['page_id'] = DataDefinition::create('string')->setLabel('Sequence ID');
       $info['parent_id'] = DataReferenceTargetDefinition::create('integer');
-//      $info['target_id'] = EntityDataDefinition::create('node')->setLabel('Parent Node ID');
       $info['target_id'] = DataReferenceDefinition::create('entity')
       ->setLabel('Parent Node ID')
       ->setComputed(TRUE)


### PR DESCRIPTION
@giancarlobi the change was so simple.

`\Drupal\Core\Entity\Plugin\DataType\EntityReference::setValue` accepts also just the integer (id) of the entity! You can eventually pass a loaded entity but we don't want over processing =) So rolling this back to your original way of setting the value but with the better data definition we have now (which means we don't need to load the node, just pass $splitted_id[0]!) does the trick!

I added the parent node's UUID and i got this document ("ss_uuid":"1d4aae51-c06b-402c-8bba-9094c0b792f3")

```JSON
[{
"id":"m7pu9i-default_solr_index-strawberryfield_flavor_datasource/9:4:en",
"ss_parent_id":"9",
"ss_page_id":"4",
"ss_search_api_id":"strawberryfield_flavor_datasource/9:4:en",
"sort_X3b_en_parent_id":"%\u0000",
"index_id":"default_solr_index",
"timestamp":"2019-06-04T00:55:39Z",
"sm_context_tags":["drupal_X2f_langcode_X3a_und",
"search_api_X2f_index_X3a_default_solr_index",
"search_api_solr_X2f_site_hash_X3a_m7pu9i"],
"ss_uuid":"1d4aae51-c06b-402c-8bba-9094c0b792f3",
"sort_X3b_en_uuid":"\u00150\u001b**2\u001d\u0015\u0005\u000e.\u0013\u001f,\u0005\u000e\u001b\u0013\u0017.\u0005\u000e#,,*\u0005\u000e%\u0013%\u001b.\u0013,!%\u00174\u0019\u0000",
"site":"http://localhost:8001/", "boost_document":1.0,
"_version_":1635369343211536384,
"ss_fulltext":"Start 4 End",
"ss_search_api_datasource":"strawberryfield_flavor_datasource",
"sort_X3b_en_page_id":"\u001b\u0000",
"hash":"m7pu9i",
"sort_X3b_en_fulltext":"NP*LP\u0004\u001b\u00042D0\u0000",
"ss_search_api_language":"und"
}]
````

Success!

Now we can go to actually adding the HOCR. Working now on adding the Flavor services as plugins. Will require some iterations. Do you think we need a custom tracker too?

Feel free to merge to test. I will make another branch for the plugins. happy!