### PR TITLE
ISSUE-47: UUID node up-caster for Routes that have as parameter 'ado' as resource_type

### DIFF
--- a/src/ParamConverter/UuidEntityConverter.php
+++ b/src/ParamConverter/UuidEntityConverter.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * @file
+ * Contains UuidEntityConverter.php
+ *
+ * @author Diego Pino Navarro <dpino@metro.org> https://github.com/diegopino
+ */
+
+namespace Drupal\strawberryfield\ParamConverter;
+
+
+use Drupal\Core\ParamConverter\EntityConverter;
+use Symfony\Component\Routing\Route;
+use Drupal\Core\Plugin\Context\Context;
+use Drupal\Core\Plugin\Context\ContextDefinition;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+
+/**
+ * Converts an UUID into a valid Content Entity.
+ *
+ * @ingroup strawberryfield
+ */
+class UuidEntityConverter extends EntityConverter {
+
+
+  /**
+   * @inheritDoc
+   */
+  public function convert($value, $definition, $name, array $defaults) {
+
+    $entity_type_id = $this->getEntityTypeFromDefaults(
+      $definition,
+      $name,
+      $defaults
+    );
+    $uuid_key = $this->entityTypeManager->getDefinition($entity_type_id)
+      ->getKey('uuid');
+
+    if ($storage = $this->entityTypeManager->getStorage($entity_type_id)) {
+      if (!$entities = $storage->loadByProperties([$uuid_key => $value])) {
+        return NULL;
+      }
+      // get the actualentity and deal with ID thing afterwards so we can deal with revisions which have
+      // no UUID. See
+      /* @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = reset($entities);
+
+      // If the entity type is revisionable and the parameter has the
+      // "load_latest_revision" flag, load the active variant.
+      if (!empty($definition['load_latest_revision'])) {
+        return $this->entityRepository->getActive(
+          $entity_type_id,
+          $entity->id()
+        );
+      }
+
+      // Do not inject the context repository as it is not an actual dependency:
+      // it will be removed once both the TODOs below are fixed.
+      /** @var \Drupal\Core\Plugin\Context\ContextRepositoryInterface $contexts_repository */
+      $contexts_repository = \Drupal::service('context.repository');
+      // @todo Consider deprecating the legacy context operation altogether in
+      //   https://www.drupal.org/node/3031124.
+      $contexts = $contexts_repository->getAvailableContexts();
+      $contexts[EntityRepositoryInterface::CONTEXT_ID_LEGACY_CONTEXT_OPERATION] =
+        new Context(new ContextDefinition('string'), 'entity_upcast');
+      // @todo At the moment we do not need the current user context, which is
+      //   triggering some test failures. We can remove these lines once
+      //   https://www.drupal.org/node/2934192 is fixed.
+      $context_id = '@user.current_user_context:current_user';
+      if (isset($contexts[$context_id])) {
+        $account = $contexts[$context_id]->getContextValue();
+        unset($account->_skipProtectedUserFieldConstraint);
+        unset($contexts[$context_id]);
+      }
+      $entity = $this->entityRepository->getCanonical(
+        $entity_type_id,
+        $entity->id(),
+        $contexts
+      );
+
+      return $entity;
+
+    }
+
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies($definition, $name, Route $route) {
+
+    $route_parameters = $route->getOption('parameters');
+    $is_ado = (isset($route_parameters['resource_type']['type']) && $route_parameters['resource_type']['type'] == 'ado') ? TRUE : FALSE;
+
+    return (
+      !empty($definition['type']) && strpos(
+        $definition['type'],
+        'entity:node'
+      ) === 0 && $is_ado
+    );
+  }
+
+}

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -41,3 +41,8 @@ services:
     tags:
       - {name: event_subscriber}
     arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister']
+  strawberryfield.paramconverter.entity:
+    class: Drupal\strawberryfield\ParamConverter\UuidEntityConverter
+    tags:
+      - { name: paramconverter , priority: 10 }
+    arguments: ['@entity_type.manager']


### PR DESCRIPTION
# What is new?

See #47 

To see this in action, momentary (until we merge all). fetch and checkout this branch https://github.com/esmero/strawberryfield/tree/ISSUE-47

in the format_strawberryfield module

either:
A)
edit `format_strawberryfield.routing.yml` and replace 

format_strawberryfield.metadatadisplay_caster: with
```YAML
format_strawberryfield.metadatadisplay_caster:
  path: '/do/{node}/metadata/{metadataexposeconfig_entity}/{format}'
  methods: [GET]
  defaults:
    _controller: '\Drupal\format_strawberryfield\Controller\MetadataExposeDisplayController::castViaTwig'
  options:
    parameters:
      node:
        type: 'entity:node'
      metadataexposeconfig_entity:
        type: 'entity:metadataexpose_entity'
      resource_type:
        type: 'ado'
  requirements:
    format: .+
    _entity_access: 'node.view'
```

or B)

Test with https://github.com/esmero/format_strawberryfield/pull/32

If you have an active Metadata exposed endpoint, like i have at
http://localhost:8001/do/394dbfb7-3676-4963-a4e0-4adef7c84dfa/metadata/iiifmanifest/manifest.jsonld

clear caches first. docker exec -ti esmero-php bash -c "drush cr"
Then navigate to any Digital Object and add to the url /metadata/nameofyourendopint/manifest.jsonld (if the settings match). 

Node should load correctly

This is needed and does not affect anything else  (thanks to `public function applies($definition, $name, Route $route) {`)

@marlo-longley ping
