### PR TITLE
ISSUE-46: Provide a JMESPath option to expose parsed results as a Field property

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -44,6 +44,17 @@ strawberryfield.strawberry_keynameprovider.flavor:
       type: string
       label: 'The field property we expose for the Strawberryfield'
 
+strawberryfield.strawberry_keynameprovider.jmespath:
+  type: config_object
+  label: 'Strawberry Key Name Provider JMesPath specific config'
+  mapping:
+    source_key:
+      type: string
+      label: 'A Comma separated string containing one or more JMESPaths '
+    exposed_key:
+      type: string
+      label: 'The field property we expose for the Strawberryfield'
+
 strawberryfield.storage_settings:
   type: config_object
   label: 'Strawberry Storage specific config'

--- a/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 9/18/18
+ * Time: 8:21 PM
+ */
+namespace Drupal\strawberryfield\Plugin\DataType;
+use Drupal\Core\TypedData\Plugin\DataType\ItemList;
+use Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+
+class StrawberryValuesViaJmesPathFromJson extends ItemList {
+  /**
+   * Cached processed value.
+   *
+   * @var array|null
+   */
+  protected $processed = NULL;
+  /**
+   * Whether the values have already been computed or not.
+   *
+   * @var bool
+   */
+  protected $computed = FALSE;
+  /**
+   * Keyed array of items.
+   *
+   * @var \Drupal\Core\TypedData\TypedDataInterface[]
+   */
+  protected $list = [];
+  public function getValue() {
+    if ($this->processed == NULL) {
+      $this->process();
+    }
+    $values = [];
+    foreach ($this->list as $delta => $item) {
+      $values[$delta] = $item->getValue();
+    }
+    return $values;
+  }
+  /**
+   * @param null $langcode
+   *
+   */
+  public function process($langcode = NULL)
+  {
+    if ($this->computed == TRUE) {
+      return;
+    }
+    $values = [];
+    $item = $this->getParent();
+    if (!empty($item->value)) {
+      /* @var $item StrawberryFieldItem */
+      $flattened = $item->provideFlatten(FALSE);
+      $definition = $this->getDataDefinition();
+      // This key is passed by the property definition in the field class
+      // jsonkey in this context is a string containing one or more
+      // jmespath's separated by comma.
+      $jmespaths = $definition['settings']['jsonkey'];
+      $jmespath_array = array_map('trim', explode(',', $jmespaths));
+      $jmespath_result = [];
+      foreach ($jmespath_array as $jmespath) {
+        $jmespath_result[] = $item->searchPath($jmespath,FALSE);
+      }
+      $jmespath_result_to_expose = [];
+
+        foreach ($jmespath_result as $item) {
+          if (is_array($item)) {
+            if (StrawberryfieldJsonHelper::arrayIsMultiSimple($item)) {
+              // @TODO should we allow unicode directly?
+              // If its multidimensional simple json encode as a string.
+              // We could also just get the first order values?
+              // @TODO, ask the team.
+              $jmespath_result_to_expose[] = json_encode($item, JSON_UNESCAPED_UNICODE|JSON_UNESCAPED_SLASHES);
+            } else {
+              $jmespath_result_to_expose = array_merge($jmespath_result_to_expose, $item);
+            }
+
+          }
+          else {
+            // If a single value, simply cast to array
+            $jmespath_result_to_expose[] = $item;
+          }
+        }
+        // This is an array, don't double nest to make the normalizer happy.
+        $values = array_map('trim', $jmespath_result_to_expose);
+        $values = array_map('stripslashes', $values);
+
+      $this->processed = array_values($values);
+      foreach ($this->processed as $delta => $item) {
+        $this->list[$delta] = $this->createItem($delta, $item);
+      }
+    }
+    else {
+      $this->processed = [];
+    }
+    $this->computed = TRUE;
+  }
+  /**
+   * Ensures that values are only computed once.
+   */
+  protected function ensureComputedValue() {
+    if ($this->computed === FALSE) {
+      $this->process();
+    }
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function setValue($values, $notify = TRUE) {
+    // Nothing to set
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function getString() {
+    $this->ensureComputedValue();
+    return parent::getString();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function get($index) {
+    if (!is_numeric($index)) {
+      throw new \InvalidArgumentException('Unable to get a value with a non-numeric delta in a list.');
+    }
+    $this->ensureComputedValue();
+    return isset($this->list[$index]) ? $this->list[$index] : NULL;
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function set($index, $value) {
+    $this->ensureComputedValue();
+    return parent::set($index, $value);
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function appendItem($value = NULL) {
+    $this->ensureComputedValue();
+    return parent::appendItem($value);
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function removeItem($index) {
+    $this->ensureComputedValue();
+    return parent::removeItem($index);
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function isEmpty() {
+    $this->ensureComputedValue();
+    return parent::isEmpty();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function offsetExists($offset) {
+    $this->ensureComputedValue();
+    return parent::offsetExists($offset);
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function getIterator() {
+    $this->ensureComputedValue();
+    return parent::getIterator();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function count() {
+    $this->ensureComputedValue();
+    return parent::count();
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function applyDefaultValue($notify = TRUE) {
+    return $this;
+  }
+}
+

--- a/src/Plugin/StrawberryfieldKeyNameProvider/JmesPathNameProvider.php
+++ b/src/Plugin/StrawberryfieldKeyNameProvider/JmesPathNameProvider.php
@@ -66,7 +66,7 @@ class JmesPathNameProvider extends StrawberryfieldKeyNameProviderBase {
       '#size' => 40,
       '#maxlength' => 255,
       '#default_value' => $this->getConfiguration()['source_key'],
-      '#description' => $this->t('JMespath(s) will be evaluated against your <em>Strawberry field</em> JSON to extract data.<br> e.g. ap:hocr'),
+      '#description' => $this->t('JMespath(s) will be evaluated against your <em>Strawberry field</em> JSON to extract data.<br> e.g. subject_loc[*].label'),
       '#required' => true,
     ];
     // We need the parent form structure, if any, to make machine name work.

--- a/src/Plugin/StrawberryfieldKeyNameProvider/JmesPathNameProvider.php
+++ b/src/Plugin/StrawberryfieldKeyNameProvider/JmesPathNameProvider.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 10/7/18
+ * Time: 3:59 PM
+ */
+
+namespace Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProvider;
+
+use Drupal\Core\Annotation\Translation;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProviderBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Component\Utility\UrlHelper;
+use GuzzleHttp\Exception\ClientException;
+use Drupal\Core\Cache\CacheBackendInterface;
+
+
+/**
+ *
+ * Flavor Strawberry Field Key Name Provider
+ *
+ * @StrawberryfieldKeyNameProvider(
+ *    id = "jmespath",
+ *    label = @Translation("JmesPath Strawberry Field Key Name Provider"),
+ *    processor_class = "\Drupal\strawberryfield\Plugin\DataType\StrawberryValuesViaJmesPathFromJson",
+ *    item_type = "string"
+ * )
+ */
+class JmesPathNameProvider extends StrawberryfieldKeyNameProviderBase {
+
+  public function calculateDependencies() {
+    // TODO: Implement calculateDependencies() method.
+  }
+
+  public function getFormClass($operation) {
+    // TODO: Implement getFormClass() method.
+  }
+
+  public function hasFormClass($operation) {
+    // TODO: Implement hasFormClass() method.
+  }
+
+  public function defaultConfiguration() {
+    return [
+        // Example ap:hocr
+        'source_key' => '',
+        // Example hocr
+        'exposed_key' => '',
+        // The id of the config entity from where these values came from.'
+        'configEntity' => NULL
+      ] + parent::defaultConfiguration();
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function settingsForm(array $parents, FormStateInterface $form_state) {
+
+    $element['source_key'] = [
+      '#id' => 'source_key',
+      '#type' => 'textfield',
+      '#title' => $this->t('One or more comma separated valid JMESPaths.'),
+      '#size' => 40,
+      '#maxlength' => 255,
+      '#default_value' => $this->getConfiguration()['source_key'],
+      '#description' => $this->t('JMespath(s) will be evaluated against your <em>Strawberry field</em> JSON to extract data.<br> e.g. ap:hocr'),
+      '#required' => true,
+    ];
+    // We need the parent form structure, if any, to make machine name work.
+    $exposed_key_parents = $parents;
+    $exposed_key_parents[] = 'source_key';
+
+    $element['exposed_key'] = [
+      '#type' => 'machine_name',
+      '#title' => $this->t('Exposed <em>Strawberry field</em> property name'),
+      '#machine_name' => [
+        'label' => '<br/>' . $this->t('Exposed Strawberry Field Property'),
+        'exists' => [$this, 'exists'],
+        'source' => $exposed_key_parents,
+      ],
+      '#default_value' => $this->getConfiguration()['exposed_key'],
+      '#description' => $this->t('Enter a value for the exposed property name. This is how the property will be available for Drupal, e.g the Search API.'),
+      '#required' => true,
+    ];
+
+    return $element;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function provideKeyNames(string $config_entity_id = NULL) {
+    // We always return an array  property => jsonkey
+    // Both values are required
+    $key = $this->getConfiguration()['exposed_key'] && $this->getConfiguration()['source_key'] ?
+      [$this->getConfiguration()['exposed_key'] => $this->getConfiguration()['source_key']]:
+      [];
+    return $key;
+  }
+
+  /**
+   * @param string $key
+   *   The field property key.
+   * @return bool
+   *   TRUE if the field property key, FALSE otherwise.
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function exists($key) {
+    // Selects all config entities of strawberry_keynameprovider that are of this plugin type!
+    $plugin_config_entities = $this->entityTypeManager->getStorage('strawberry_keynameprovider')->loadByProperties(['pluginid' => $this->getPluginId()]);
+    if (count($plugin_config_entities))  {
+      /* @var keyNameProviderEntity[] $plugin_config_entities */
+      foreach($plugin_config_entities as $plugin_config_entity) {
+          $configuration_options = $plugin_config_entity->getPluginconfig();
+          if ($configuration_options['exposed_key'] == $key) {
+            return TRUE;
+          }
+      }
+    }
+    return FALSE;
+  }
+
+
+
+}

--- a/src/Plugin/StrawberryfieldKeyNameProviderManager.php
+++ b/src/Plugin/StrawberryfieldKeyNameProviderManager.php
@@ -16,7 +16,7 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 /**
  * Provides the Strawberryfield KeyName Provider Plugin  Manager.
  *
- * Class StrabwerryfieldKeyNameProviderManager
+ * Class StrawberryfieldKeyNameProviderManager
  *
  * @package Drupal\strawberryfield\Plugin
  */

--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -283,10 +283,29 @@ class StrawberryfieldJsonHelper {
    * @param array $sourcearray
    *
    * @return bool
+   *  TRUE if is associative
    */
-  public static function jsonIsList(array $sourcearray =  []) {
-      return empty(array_filter(array_keys($sourcearray), 'is_string'));
+  public static function arrayIsMultiSimple(array $sourcearray =  []) {
+      return !empty(array_filter(array_keys($sourcearray), 'is_string'));
   }
+
+  /**
+   * Another array helper that checks if an array is associative or not
+   *
+   * This is faster for large arrays than ::jsonIsList()
+   * @param array $sourcearray
+   *
+   * @return bool
+   *  TRUE if is associative
+   */
+  public static function arrayIsMultiIterative(array $sourcearray =  []) {
+    foreach ($sourcearray as $item) {
+      if (is_array($item)) return true;
+    }
+    return false;
+  }
+
+
 
   /**
    *
@@ -314,4 +333,64 @@ class StrawberryfieldJsonHelper {
     return (bool) preg_match(self::URN_REGEXP, $uri);
   }
 
+  /**
+   * Transforms our stored JSON Property Paths/Tax. terms into a valid JMESPath.
+   *
+   * This function assumes the given JSON Property path lacks the
+   * last .[] or .{} present in the return expression of a JMESPath.
+   * Basically it translates thing like
+   *  `ap:images.*.url` into
+   *  `"ap:images".*.url"
+   *  or
+   *  `subject_loc.[*].label` into
+   *  `subject_loc[*].label"
+   *
+   * NOTE: This function is not meant to deal with full JSON Path expressions
+   * and value based selectors.
+   *
+   * @param $jsonproppath
+   *
+   * @return string
+   */
+  public static function jsonPropertyPathToJmesPath($jsonproppath) {
+    $path_parts_raw = explode(".", $jsonproppath);
+
+    $terms = new CachingIterator(
+      new ArrayIterator($path_parts_raw)
+    );
+    $term_path = [];
+    foreach ($terms as $json_node) {
+      if ($terms->hasNext()) {
+        $next = $terms->getInnerIterator()->current();
+        if ($next == '*') {
+          $term_path[] = $json_node . "." . $next;
+          continue;
+        }
+        elseif ($next == '[*]') {
+          $term_path[] = $json_node . $next;
+          continue;
+        }
+      }
+      if ($json_node != '[*]' && $json_node != '*') {
+        $term_path[] = self::surroundInDuobleQuotes($json_node);
+      }
+    }
+      $term_path = array_filter($term_path);
+      $jmespath = implode('.',$term_path);
+    return $jmespath;
+  }
+
+
+  /**
+   * Simple helper method that surrounds strings with : in doublequotes
+   * @param $string
+   *
+   * @return string
+   */
+  public static function surroundInDuobleQuotes($string) {
+    // For the sake of performance. Just surround everything.
+    // If we check for : or @ or ! we would be doing a lot of
+    // Extra processing when JMESPATH loves already double quotes.
+    return '"' . $string . '"';
+  }
 }

--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -292,7 +292,7 @@ class StrawberryfieldJsonHelper {
   /**
    * Another array helper that checks if an array is associative or not
    *
-   * This is faster for large arrays than ::jsonIsList()
+   * This is faster for large arrays than ::arrayIsMultiSimple()
    * @param array $sourcearray
    *
    * @return bool


### PR DESCRIPTION
# What is new?

See #46. This is just one of the listed there. But we are moving forward.

This is just good, lovely and needed. 
This pull provides the following new options:

1. A new JSON Key Name Provider Plugin that deals with JMESPath processing to populate a given Strawberryfield exposed property (For Solr). This Plugin allows a comma separated string of JMESPaths, which means we can take a few different values from all over the JSON and expose them as a single Solr Field/Facet. This also gives us the change to target pretty specific values in a complex hierarchical JSON.

2. A New `DataType` extended from `itemList` matching the new Plugin. It does some smart things like checking if the JMESPath results are actually just an array of values or a Multidimensional Array. In the later case, it JSONEncodes the values and gives a string back. If that is the case, it is really not useful for faceting, true, but yes for free search.

3. New helper methods on our `StrawberryfieldJsonHelper`class including
`::arrayIsMultiSimple(array $sourcearray =  [])`
Simplistic checker for Multidimensional Arrays. Not so fast but pretty, good for small arrays like what we would get from a SBF evaluated against a JMESPath
`::arrayIsMultiIterative(array $sourcearray =  [])`
Pretty similiar (same input/output) but uses a foreach. Which for larger arrays is way faster. Probably useful when working on Find and Replace and larger serializations.
`::jsonPropertyPathToJmesPath($jsonproppath)`
A function that converts JSONPath syntax into a valid JMESPath syntax. Deals with simple use cases, not complex casting of results, but will be used when parsing our existing Vocabularies/Paths into valid JMESPaths

# How to test?

- Checkout this Branch
- Clear Caches
- Go to `/admin/structure/strawberry_keynameprovider`
- Press `Add Key Name Provider`
- Give it a Label: `Subjects`
- Select the new Plugin from "Strawberry Key Name Provider Plugin" named JmesPath Strawberry Field Key Name provider. Ajax will give you more options down there.
- Under `One or more comma separated valid JMESPaths.` write the following:
`subject_loc[*].label, subject_wikidata[*].label`
Which in JMESPath logic means, take all `label` values in any List item under `subject_loc` JSON key, and take all `label` values  in any List item under `subject_wikidata` JSON Key
Under the Input you will see a Machine name (Exposed Strawberry Field Property: subject_loc_uri). Press `Edit`and change it to `all_subjects`.

Press `Save`. Clear Caches (just in case)

Now go to your Search Index and add a new Field from Descriptive Metadata. Search for the new `all_subjects` property.
You can also add this one (so you see this is working!) as a new Facet, and expose the Facet block.

Now you will have a new facet block that joins all the labels coming from Wikidata and LoC Subjects in the same place. Pretty handy!

# Other Uses
Simple stuff. Like just expose the Primary `type` key instead of all the `type` keys (guess what!, the JMESPath for that is `type` jajaja). Also, if JMespath is as simply i could add logic to avoid doing a JMEspath query at all. Internal `@TODO`, no need to expose people to the choice.

# What is next

- Allow people to select the JMESPaths from our existing Vocab using autocomplete, since we are already keeping track of all Paths on Save. That would lover the barrier.

- Add some smarter things here. I wish in the future we had less Cache clearing, which is really something we can do by triggering that on save.

- Allow people to evaluate the JMesPaths agains a choosen ADO. That way they can see results before committing to a given Query. Right now you can also do some test on a terminal via JPTerm. Pretty handy for learning JMESPath. See https://github.com/jmespath/jmespath.terminal

- Add more validation and checks. This is really missing. Specially on that Settings form.

Thoughts? @giancarlobi @marlo-longley 
Thanks!

