### PR TITLE
ISSUE-53: Create new Config page for Solr settings

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -66,20 +66,6 @@ strawberryfield.storage_settings:
       type: string
       label: 'Storage Scheme for Persisting Digital Objects in JSON format'
       
-xstrawberryfield.archipelago_solr_settings:
-  type: config_object
-  label: 'Important Solr settings for Archipelago'
-  mapping:
-    type_server: 
-      type: string
-      label: 'The Solr server for type in ADO to View Mode mapping'
-    type_index:
-      type: string
-      label: 'The Solr index used for type in ADO to View Mode mapping'
-    type_field:
-      type: string
-      label: 'The Solr field used for type in ADO to View Mode mapping'
-      
 strawberryfield.archipelago_solr_settings:
   type: config_object
   label: 'Important Solr Settings for Archipelago'

--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -65,3 +65,17 @@ strawberryfield.storage_settings:
     object_file_scheme:
       type: string
       label: 'Storage Scheme for Persisting Digital Objects in JSON format'
+      
+strawberryfield.archipelago_solr_settings:
+  type: config_object
+  label: 'Important Solr settings for Archipelago'
+  mapping:
+    type_server: 
+      type: string
+      label: 'The Solr server for type in ADO to View Mode mapping'
+    type_index:
+      type: string
+      label: 'The Solr index used for type in ADO to View Mode mapping'
+    type_field:
+      type: string
+      label: 'The Solr field used for type in ADO to View Mode mapping'

--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -66,7 +66,7 @@ strawberryfield.storage_settings:
       type: string
       label: 'Storage Scheme for Persisting Digital Objects in JSON format'
       
-strawberryfield.archipelago_solr_settings:
+xstrawberryfield.archipelago_solr_settings:
   type: config_object
   label: 'Important Solr settings for Archipelago'
   mapping:
@@ -79,3 +79,23 @@ strawberryfield.archipelago_solr_settings:
     type_field:
       type: string
       label: 'The Solr field used for type in ADO to View Mode mapping'
+      
+strawberryfield.archipelago_solr_settings:
+  type: config_object
+  label: 'Important Solr Settings for Archipelago'
+  mapping:
+    ado_type:
+      type: strawberryfield.archipelago_solr_settings.field_config
+      label: 'Source for Archipelago Digital Object Type'
+      
+strawberryfield.archipelago_solr_settings.field_config:
+  type: mapping
+  label: 'Field Config for Archipelago Solr Settings'
+  mapping:
+    index_id:
+      type: string
+      label: 'ID of Solr Index'
+    field:
+      type: string
+      label: 'Solr Field'
+      

--- a/src/Form/ImportantSolrSettingsForm.php
+++ b/src/Form/ImportantSolrSettingsForm.php
@@ -30,33 +30,38 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $sbfUtiliy;
-  
+
   protected $solrServers;
-  
+
   /**
    * Constructs an ImportantSolrSettingsForm object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
-   * 
+   *
    * * @param \Drupal\strawberryfield\StrawberryfieldUtilityService $sbf_utility
    *   SBF Utility Service
-   * 
+   *
    * * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, StrawberryfieldUtilityService $sbf_utility, ConfigFactoryInterface $config_factory) {
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    StrawberryfieldUtilityService $sbf_utility,
+    ConfigFactoryInterface $config_factory
+  ) {
     $this->entityTypeManager = $entity_type_manager;
     $this->sbfUtiliy = $sbf_utility;
     $this->setConfigFactory($config_factory);
-    $this->solrServers = $entity_type_manager->getStorage('search_api_server')->loadMultiple();
+    $this->solrServers = $entity_type_manager->getStorage('search_api_server')
+      ->loadMultiple();
   }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
-    
+
     return new static(
       $container->get('entity_type.manager'),
       $container->get('strawberryfield.utility'),
@@ -78,32 +83,32 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function getFormId() {
-    
+
     return 'strawberryfield_important_solr_settings_form';
   }
 
   /**
    * Formats array into correct format for Form API #options
-   * 
+   *
    * @param array
-   * 
+   *
    * @return array
    */
   public function formatOptions($array) {
-    $options = array();
+    $options = [];
     foreach ($array as $key => $item) {
       $options[$key] = $item->label();
     }
-    
+
     return $options;
   }
-  
+
   /**
    * Returns the ID of the Solr Server of a given index
-   * 
-   * @param \Drupal\search_api\Entity\Index $index 
+   *
+   * @param \Drupal\search_api\Entity\Index $index
    *   A Solr Index Entity
-   * 
+   *
    * @return string
    *   The index's server ID
    */
@@ -111,10 +116,10 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
 
     return $index->getServerId();
   }
-  
+
 
   public function getIndex($index_id) {
-    
+
     return $this->entityTypeManager
       ->getStorage('search_api_index')
       ->load($index_id);
@@ -122,29 +127,32 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
 
   /**
    * Takes a given Solr server and returns all its indexes
-   * 
-   * @param $server
+   *
+   * @param string|null $server
    *   The solr server we use to then get its indexes
-   * 
+   *
    * @return array
    *   array of indexes formatted for #options
    */
   public function getIndexes($server) {
-      // Get all indexes 
-      $indexes = $this->entityTypeManager
-        ->getStorage('search_api_index')
-        ->loadMultiple();
+    // Get all indexes
+    /* @var $indexes \Drupal\search_api\IndexInterface[] */
+    $indexes = $this->entityTypeManager
+      ->getStorage('search_api_index')
+      ->loadMultiple();
 
-      // Add the indexes with matching server to $indexes_by_server
-      $indexes_by_server = array();
-      foreach ($indexes as $key => $index) {
+    // Add the indexes with matching server to $indexes_by_server
+    $indexes_by_server = [];
+    foreach ($indexes as $key => $index) {
+      if ($index->isServerEnabled()) {
         $s = $index->getServerId();
         if ($s === $server) {
           $indexes_by_server[$key] = $index->label();
         }
       }
-      
-      return $indexes_by_server;
+    }
+
+    return $indexes_by_server;
   }
 
   /**
@@ -158,44 +166,41 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    */
   public function getSolrFields($selected_index_entity) {
     // filter only for SBF related Solr fields
-    $sbf_solr_fields = $this->sbfUtiliy->getStrawberryfieldSolrFields($selected_index_entity);
-    
+    $sbf_solr_fields = $this->sbfUtiliy->getStrawberryfieldSolrFields(
+      $selected_index_entity
+    );
+
     // format for #options
-    $formatted_fields = array();
-    foreach ($sbf_solr_fields as $key => $field) {
-      $formatted_fields[$key] = $field['label'];
+    $formatted_fields = [];
+    foreach ($sbf_solr_fields as $id => $field) {
+      $formatted_fields[$id] = $field['label'];
     }
-    
+
     return $formatted_fields;
   }
-  
+
   /**
    * AJAX callback function when user selects Solr Server
-   * 
+   *
    * Updates both Index and Solr Field dropdowns in the returned AjaxResponse
    */
   public function onServerSelect(array &$form, FormStateInterface $form_state) {
     $response = new AjaxResponse();
 
     if ($form_state->getValue('server_select')) {
-      // Pass the selected server to get its indexes
-      $indexes_by_server = $this->getIndexes($form_state->getValue('server_select'));
-      // As a default for this new selection, use the first index the array and fetch its fields
-      $index_entity = $this->getIndex(array_key_first($indexes_by_server));
-      $fields = $this->getSolrFields($index_entity);
-
-      // Set the new #options for Index
-      $form['ado_type']['index_select']['#options'] = $indexes_by_server;
-      // Set the new #options for Solr Field
-      $form['ado_type']['solr_field_select']['#options'] = $fields;
-
-      // Construct our own response to return/change multiple form fields
-      $response->addCommand(new ReplaceCommand("#index-select", ($form['ado_type']['index_select'])));
-      $response->addCommand(new ReplaceCommand("#solr-field-select", ($form['ado_type']['solr_field_select'])));
+      $response->addCommand(
+        new ReplaceCommand("#index-select", ($form['ado_type']['index_select']))
+      );
+      $response->addCommand(
+        new ReplaceCommand(
+          "#solr-field-select",
+          ($form['ado_type']['solr_field_select'])
+        )
+      );
     }
-    
+
     return $response;
-   }
+  }
 
   /**
    * AJAX callback function when user selects Index
@@ -203,66 +208,100 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    * Updates Solr Field dropdown
    */
   public function onIndexSelect(array &$form, FormStateInterface $form_state) {
-    // Get solr fields for selected Index
-    $selected_index_id = $form_state->getValue('index_select');
-    $fields = $this->getSolrFields($this->getIndex($selected_index_id));
-    
-    // Construct our own response to return/change multiple form fields
+
     $response = new AjaxResponse();
-    
-    if ($fields) {
-      $form['ado_type']['solr_field_select']['#options'] = $fields ;
-      $response->addCommand(new ReplaceCommand("#solr-field-select", ($form['ado_type']['solr_field_select'])));
-    } else {
-      $url = '/admin/config/search/search-api/index/'.$selected_index_id.'/fields';
-      $form['ado_type']['no-fields']['#markup'] = '<p class=\'color-error\'>You cannot complete this form. <br> There are currently no Solr Fields for this index that can be used with ADOs. <br> Please set up a Solr Field based on Strawberryfield content <a href='.$url.'><b>here</b></a> and return.</p>';
-      $response->addCommand(new ReplaceCommand("#no-fields", ($form['ado_type']['no-fields'])));
+    if ($form_state->getValue('index_select')) {
+      $response->addCommand(
+        new ReplaceCommand(
+          "#solr-field-select",
+          ($form['ado_type']['solr_field_select'])
+        )
+      );
+      $response->addCommand(
+        new ReplaceCommand(
+          "#no-fields", ($form['ado_type']['no-fields'])
+        )
+      );
     }
-    
+
     return $response;
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $ado_type_config = $this->config('strawberryfield.archipelago_solr_settings.ado_type');
-    
-    // Assume these aren't set yet (no config)
-    $index_id = '';
-    $index_entity = null;
-    $server = '';
-    
-    $has_index_config = !empty($ado_type_config->get('index_id'));
-    // If there is config, use the values
-    if ($has_index_config) {
-      $index_id = $ado_type_config->get('index_id');
+
+    if (empty($this->solrServers)) {
+      // Create replacement fieldset in the case of no existing Solr Servers.
+      $form['no-servers-message'] = [
+        '#type' => 'fieldset',
+        '#title' => $this->t('Source for Archipelago Digital Object Type'),
+        '#markup' => '<p>No existing Search API Servers. Please visit <a href=" /admin/config/search/search-api/">Search API Config</a> to set one up, and then return to this form.</p>',
+      ];
+      return $form;
+
+    }
+
+    $ado_type_config = $this->config(
+      'strawberryfield.archipelago_solr_settings.ado_type'
+    );
+
+    // Note: this all could go into the constructor. No need to load things each
+    // time the Form rebuilds.
+    $index_id = $ado_type_config->get('index_id');
+    $field = $ado_type_config->get('field');
+
+    // Defaults
+    $index_entity = NULL;
+    $server = NULL;
+    $solr_fields = [];
+    $indexes_by_server = [];
+
+    if ($form_state->isRebuilding()) {
+      // Idea here is: rebuilding means user submitted values,
+      // So our original Config is not longer valid
+      // We use what is passed around.
+      $server = !empty(
+      $form_state->getValue(
+        'server_select'
+      )
+      ) ? $form_state->getValue('server_select') : NULL;
+      $indexes_by_server = $this->getIndexes($server);
+      $index_id = !empty(
+      $form_state->getValue(
+        'index_select'
+      )
+      ) ? $form_state->getValue('index_select') : NULL;
+      // NO need to get 'solr_field_select' from form state
+      // since its the last step and would only
+      // trigger a rebuild if index or server changes.
+    }
+
+
+    if ($index_id) {
       // Get full index entity based on the index_id stored in config
       $index_entity = $this->getIndex($index_id);
       // use the built-in index entity method to get its server_id
       $server = $index_entity->getServerId();
+      // Todo: Check if we need to call  this again?
+      $indexes_by_server = $this->getIndexes($server);
+      $solr_fields = $this->getSolrFields($index_entity);
     }
-    
-    // Create replacement fieldset in the case of no existing Solr Servers
-    $form['no-servers-message'] = [
-      '#type' => empty($this->solrServers) ? 'fieldset' : 'hidden',
-      '#title' => $this->t('Source for Archipelago Digital Object Type'),
-      '#markup' => '<p>No existing Solr Servers. Please visit <a href=" /admin/config/search/search-api/">Search API Config</a> to set one up, and then return to this form.</p>',
-    ];
 
     // Create a fieldset for the ADO Type settings, visible when servers exist
     $form['ado_type'] = [
-      '#type' => empty($this->solrServers) ? 'hidden' : 'fieldset',
+      '#type' => 'fieldset',
       '#title' => $this->t('Source for Archipelago Digital Object Type'),
-      '#markup' => '<p>Choose the Solr field that determines an ADO\'s Type. Type is then used across Archipelago. <br><br> Fields are specific to their Solr Server and Index. <br> To edit servers, indexes, and fields, visit <a href=" /admin/config/search/search-api/">Search API Config</a><br> For info and settings about the View Mode mapper, visit the <a href="/admin/config/archipelago/viewmode_mapping">ADO to View Mode Config</a></p>'
+      '#markup' => '<p>Choose the Solr field that determines an ADO\'s Type. Type is then used across Archipelago. <br><br> Fields are specific to their Solr Server and Index. <br> To edit servers, indexes, and fields, visit <a href=" /admin/config/search/search-api/">Search API Config</a><br> For info and settings about the View Mode mapper, visit the <a href="/admin/config/archipelago/viewmode_mapping">ADO to View Mode Config</a></p>',
     ];
-      
+
     $form['ado_type']['server_select'] = [
       '#type' => 'select',
       '#title' => $this->t('Step 1. Select Server'),
       '#options' => $this->formatOptions($this->solrServers),
       '#default_value' => $server,
-      "#empty_value" => '',
+      "#empty_value" => NULL,
       '#empty_option' => '- Select Server -',
       '#required' => TRUE,
       '#ajax' => [
@@ -278,9 +317,9 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
       '#title' => $this->t('Step 2. Select Solr Index'),
       '#prefix' => '<div id="index-select">',
       '#suffix' => '</div>',
-      '#options' => $has_index_config ? $this->getIndexes($server) : null,
-      "#default_value" => $ado_type_config->get('index_id'),
-      "#empty_value" => '',
+      '#options' => $indexes_by_server,
+      "#default_value" => $index_id,
+      "#empty_value" => NULL,
       '#empty_option' => '- Select Solr Index -',
       // If not #validated, dynamically populated dropdowns don't work.
       '#validated' => TRUE,
@@ -297,63 +336,97 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
         'visible' => [
           ':input[name="server_select"]' => ['!value' => ''],
         ],
-      ]
-    ];
-    
-    // Check if there are Solr fields for this index.
-    // If not, hide the field select, and show a link to Solr Index settings from Search API instead.
-    $solr_fields = $this->getSolrFields($index_entity);
-    if ($solr_fields) {
-      $form['ado_type']['solr_field_select'] = [
-        '#type' => 'select',
-        '#title' => $this->t('Step 3. Select Solr Field'),
-        '#prefix' => '<div id="solr-field-select">',
-        '#suffix' => '</div>',
-        '#options' => $has_index_config ? $solr_fields : null,
-        "#default_value" => $ado_type_config->get('field'),
-        "#empty_value" => '',
-        '#empty_option' => '- Select Solr Field -',
-        // If not #validated, dynamically populated dropdowns don't work.
-        '#validated' => TRUE,
-        '#required' => TRUE,
-        '#states' => [
-          'visible' => [
-            ':input[name="server_select"]' => ['!value' => ''],
-          ],
+        'optional' => [
+          ':input[name="server_select"]' => ['value' => ''],
         ],
-      ];
+      ],
+    ];
+
+
+    // Check if there are Solr fields for this index.
+    $form['ado_type']['solr_field_select'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Step 3. Select Solr Field'),
+      '#prefix' => '<div id="solr-field-select">',
+      '#suffix' => '</div>',
+      '#options' => $solr_fields,
+      "#default_value" => $field,
+      "#empty_value" => NULL,
+      '#empty_option' => '- Select Solr Field -',
+      // If not #validated, dynamically populated dropdowns don't work.
+      '#validated' => TRUE,
+      '#required' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="server_select"]' => ['!value' => ''],
+          ':input[name="index_select"]' => ['!value' => ''],
+        ],
+        'optional' => [
+          ':input[name="index_select"]' => ['value' => ''],
+        ],
+      ],
+    ];
+
+    // This avoids Browser error when an JS conditionally hidden field is required.
+    if (!$server) {
+      $form['ado_type']['index_select']['#required'] = FALSE;
+    }
+    if (!$index_id) {
+      $form['ado_type']['solr_field_select']['#required'] = FALSE;
     }
 
-    if (!$solr_fields) {
+
+    if (empty($solr_fields) && $index_entity) {
+      $url = '/admin/config/search/search-api/index/' . $index_id . '/fields';
+      // Means there is an $index but its empty.
       $form['ado_type']['no-fields'] = [
-        '#markup' => '',
+        '#markup' => '<p class=\'color-error\'><br> There are currently no Solr Fields for this index that can be used with ADOs. <br> Please select another Index or set up a Solr Field based on Strawberryfield content <a href=' . $url . '><b>here</b></a> and return.</p>',
         '#prefix' => '<div id="no-fields">',
         '#suffix' => '</div>',
       ];
     }
-    
+    else {
+      // Why? Well, we want to be sure the Form builder has the chance to keep
+      // Track of this element when it initialize. Could be an overkill.
+      $form['ado_type']['no-fields'] = [
+        '#prefix' => '<div id="no-fields">',
+        '#suffix' => '</div>',
+        '#markup' => '',
+      ];
+    }
+
     return parent::buildForm($form, $form_state);
   }
 
 
   /**
-   * Submission handler for condition changes in 
+   * Submission handler for condition changes in
    */
-  function field_submit($form, &$form_state) {
+  function field_submit(array &$form, FormStateInterface $form_state) {
+    // We want to unset values here.
+    // That way, e.g in case people select an index, then a field
+    // And then a new index, solr_field_select gets always a chance to be
+    // reselected.
+    if (empty($form_state->getValue('server_select'))) {
+      $form_state->unsetValue('solr_field_select');
+      $form_state->unsetValue('index_select');
+    }
+    if (empty($form_state->getValue('index_select'))) {
+      $form_state->unsetValue('solr_field_select');
+    }
 
     $form_state->setRebuild(TRUE);
-    
   }
-  
+
   /**
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+
     $this->config('strawberryfield.archipelago_solr_settings.ado_type')
       ->set('index_id', $form_state->getValue('index_select'))
       ->set('field', $form_state->getValue('solr_field_select'))
       ->save();
-
     parent::submitForm($form, $form_state);
   }
 }

--- a/src/Form/ImportantSolrSettingsForm.php
+++ b/src/Form/ImportantSolrSettingsForm.php
@@ -1,0 +1,249 @@
+<?php
+
+namespace Drupal\strawberryfield\Form;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\ReplaceCommand;
+
+/**
+ * ConfigurationForm for which Solr field is used in ADO Type Mapping.
+ */
+class ImportantSolrSettingsForm extends ConfigFormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+  
+
+  /**
+   * Constructs an ImportantSolrSettingsForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * 
+   * * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, ConfigFactoryInterface $config_factory) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->setConfigFactory($config_factory);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'strawberryfield.archipelago_solr_settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'strawberryfield_type_solr_field_form';
+  }
+
+  /**
+   * Formats array into correct format for Form API #options
+   * 
+   * @param array
+   * 
+   * @return array
+   */
+  public function formatOptions($array) {
+    $options = array();
+    foreach ($array as $key => $item) {
+      $options[$key] = $item->label();
+    }
+    return $options;
+  }
+  
+  /**
+   * Takes a given Solr server and returns all its indexes
+   * 
+   * @param $server
+   *   The solr server we use to then get its indexes
+   * 
+   * @return array
+   *   array of indexes formatted for #options
+   */
+  public function getIndexes($server) {
+      // Get all indexes 
+      $indexes = $this->entityTypeManager
+        ->getStorage('search_api_index')
+        ->loadMultiple();
+
+      // Add the indexes with matching server to $indexes_by_server
+      $indexes_by_server = array();
+      foreach ($indexes as $key => $index) {
+        $s = $index->getServerId();
+        if ($s === $server) {
+          $indexes_by_server[$key] = $index->label();
+        }
+      }
+      
+      return $indexes_by_server;
+  }
+
+  /**
+   * Takes a Solr Index id and return its fields
+   *
+   * @param $selected_index_id
+   *   id of the solr index
+   *
+   * @return array
+   *   array of Solr fields formatted for #options
+   */
+  public function getSolrFields($selected_index_id) {
+    // get specific Index
+    $index = $this->entityTypeManager
+      ->getStorage('search_api_index')
+      ->load($selected_index_id);
+
+    // get the fields of this Index
+    $fields = $index->get('field_settings');
+
+    // format correctly for #options
+    $fields_by_index = array();
+    foreach ($fields as $key => $field) {
+      $fields_by_index[$key] = $field['label'];
+    }
+
+    return $fields_by_index;
+  }
+  
+  /**
+   * AJAX callback function when user selects Solr Server
+   * 
+   * Updates both Index and Solr Field dropdowns in the returned AjaxResponse
+   */
+  public function onServerSelect(array &$form, FormStateInterface $form_state) {
+    // Pass the selected server to get its indexes
+    $indexes_by_server = $this->getIndexes($form_state->getValue('server_select'));
+    // As a default for this new selection, use the first index the array and fetch its fields
+    $fields = $this->getSolrFields(array_key_first($indexes_by_server));
+    
+    // Set the new #options for Index
+    $form['type']['index_select']['#options'] = $indexes_by_server;
+    // Set the new #options for Solr Field
+    $form['type']['solr_field_select']['#options'] = $fields;
+
+    // Construct our own response to return/change multiple form fields
+    $response = new AjaxResponse();
+    $response->addCommand(new ReplaceCommand("#index-select", ($form['type']['index_select'])));
+    $response->addCommand(new ReplaceCommand("#solr-field-select", ($form['type']['solr_field_select'])));
+    
+    return $response;
+   }
+
+  /**
+   * AJAX callback function when user selects Index
+   *
+   * Updates Solr Field dropdown
+   */
+  public function onIndexSelect(array &$form, FormStateInterface $form_state) {
+    // Get solr fields for selected Index
+    $fields = $this->getSolrFields($form_state->getValue('index_select'));
+    $form['type']['solr_field_select']['#options'] = $fields;
+    
+    return $form['type']['solr_field_select'];  
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('strawberryfield.archipelago_solr_settings');
+    
+    // Get all Solr servers
+    $servers = $this->entityTypeManager
+      ->getStorage('search_api_server')
+      ->loadMultiple();
+
+    // Create a fieldset for the Type setting
+    $form['type'] = array(
+      '#type' => 'fieldset',
+      '#title' => $this->t('Solr Field for Type in View Mode mapping'),
+      '#markup' => '<p>Choose the Solr field that will be used in our ADO to View Mode mapper. <br><br> Fields are specific to their Solr Server and Index. <br> To edit servers, indexes, and fields, visit <a href=" /admin/config/search/search-api/">Search API Config</a><br> For info and settings about the View Mode mapper, visit the <a href="/admin/config/archipelago/viewmode_mapping">ADO to View Mode Config</a></p>'
+    );
+
+    $form['type']['server_select'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Step 1. Select Server'),
+      '#options' => $this->formatOptions($servers),
+      '#default_value' => $config->get('type_server'),
+      '#ajax' => [
+        'callback' => '::onServerSelect',
+        'disable-refocus' => FALSE,
+        'event' => 'change',
+        'wrapper' => 'index-select', 
+      ]
+    ];
+    
+    $form['type']['index_select'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Step 2. Select Solr Index'),
+      '#prefix' => '<div id="index-select">',
+      '#suffix' => '</div>',
+      '#options' => $config->get('type_server') ? $this->getIndexes($config->get('type_server')) : null,
+      "#empty_value" => "",
+      "#default_value" => $config->get('type_index'),
+      // If not #validated, dynamically populated dropdowns don't work.
+      '#validated' => TRUE,
+      '#ajax' => [
+        'callback' => '::onIndexSelect',
+        'disable-refocus' => FALSE, 
+        'event' => 'change',
+        'wrapper' => 'solr-field-select', 
+      ]
+    ];
+    
+    $form['type']['solr_field_select'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Step 3. Select Solr Field'),
+      '#prefix' => '<div id="solr-field-select">',
+      '#suffix' => '</div>',
+      '#options' => $config->get('type_server') && $config->get('type_index') ? $this->getSolrFields($config->get('type_index')) : null,
+      "#empty_value" => "",
+      "#default_value" => $config->get('type_field'),
+      // If not #validated, dynamically populated dropdowns don't work.
+      '#validated' => TRUE,
+    ];
+    
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->config('strawberryfield.archipelago_solr_settings')
+      ->set('type_server', $form_state->getValue('server_select'))
+      ->set('type_index', $form_state->getValue('index_select'))
+      ->set('type_field', $form_state->getValue('solr_field_select'))
+      ->save();
+
+    parent::submitForm($form, $form_state);
+  }
+}

--- a/src/Form/ImportantSolrSettingsForm.php
+++ b/src/Form/ImportantSolrSettingsForm.php
@@ -9,6 +9,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\search_api\Entity\Index;
 
 /**
  * ConfigurationForm for which Solr field is used in ADO Type Mapping.
@@ -52,8 +53,9 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   protected function getEditableConfigNames() {
+
     return [
-      'strawberryfield.archipelago_solr_settings',
+      'strawberryfield.archipelago_solr_settings.ado_type',
     ];
   }
 
@@ -61,7 +63,8 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function getFormId() {
-    return 'strawberryfield_type_solr_field_form';
+    
+    return 'strawberryfield_important_solr_settings_form';
   }
 
   /**
@@ -76,9 +79,32 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
     foreach ($array as $key => $item) {
       $options[$key] = $item->label();
     }
+    
     return $options;
   }
   
+  /**
+   * Returns the ID of the Solr Server of a given index
+   * 
+   * @param Drupal\search_api\Entity\Index $index 
+   *   A Solr Index Entity
+   * 
+   * @return string
+   *   The index's server ID
+   */
+  public function getServerId(Index $index) {
+
+    return $index->getServerId();
+  }
+  
+
+  public function getIndex($index_id) {
+    
+    return $this->entityTypeManager
+      ->getStorage('search_api_index')
+      ->load($index_id);
+  }
+
   /**
    * Takes a given Solr server and returns all its indexes
    * 
@@ -109,29 +135,26 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
   /**
    * Takes a Solr Index id and return its fields
    *
-   * @param $selected_index_id
+   * @param Drupal\search_api\Entity\Index $selected_index_entity
    *   id of the solr index
    *
    * @return array
    *   array of Solr fields formatted for #options
    */
-  public function getSolrFields($selected_index_id) {
-    // get specific Index
-    $index = $this->entityTypeManager
-      ->getStorage('search_api_index')
-      ->load($selected_index_id);
-
-    // get the fields of this Index
-    $fields = $index->get('field_settings');
-
-    // format correctly for #options
-    $fields_by_index = array();
-    foreach ($fields as $key => $field) {
-      $fields_by_index[$key] = $field['label'];
+  public function getSolrFields(Index $selected_index_entity) {
+    // filter only for SBF related Solr fields
+    $sbf_solr_fields = \Drupal::service('strawberryfield.utility')->getStrawberryfieldSolrFields($selected_index_entity);
+    
+    // format for #options
+    $formatted_fields = array();
+    foreach ($sbf_solr_fields as $key => $field) {
+      $formatted_fields[$key] = $field['label'];
     }
-
-    return $fields_by_index;
+    
+    return $formatted_fields;
   }
+  
+  
   
   /**
    * AJAX callback function when user selects Solr Server
@@ -145,14 +168,14 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
     $fields = $this->getSolrFields(array_key_first($indexes_by_server));
     
     // Set the new #options for Index
-    $form['type']['index_select']['#options'] = $indexes_by_server;
+    $form['ado_type']['index_select']['#options'] = $indexes_by_server;
     // Set the new #options for Solr Field
-    $form['type']['solr_field_select']['#options'] = $fields;
+    $form['ado_type']['solr_field_select']['#options'] = $fields;
 
     // Construct our own response to return/change multiple form fields
     $response = new AjaxResponse();
-    $response->addCommand(new ReplaceCommand("#index-select", ($form['type']['index_select'])));
-    $response->addCommand(new ReplaceCommand("#solr-field-select", ($form['type']['solr_field_select'])));
+    $response->addCommand(new ReplaceCommand("#index-select", ($form['ado_type']['index_select'])));
+    $response->addCommand(new ReplaceCommand("#solr-field-select", ($form['ado_type']['solr_field_select'])));
     
     return $response;
    }
@@ -164,71 +187,129 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    */
   public function onIndexSelect(array &$form, FormStateInterface $form_state) {
     // Get solr fields for selected Index
-    $fields = $this->getSolrFields($form_state->getValue('index_select'));
-    $form['type']['solr_field_select']['#options'] = $fields;
+    $selected_index_id = $form_state->getValue('index_select');
+    $fields = $this->getSolrFields($this->getIndex($selected_index_id));
+    $form['ado_type']['solr_field_select']['#options'] = $fields ? $fields : null;
     
-    return $form['type']['solr_field_select'];  
+    return $form['ado_type']['solr_field_select'];  
   }
-
+  
   /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = $this->config('strawberryfield.archipelago_solr_settings');
+    $ado_type_config = $this->config('strawberryfield.archipelago_solr_settings.ado_type');
     
     // Get all Solr servers
     $servers = $this->entityTypeManager
       ->getStorage('search_api_server')
       ->loadMultiple();
+    
+    // Assume these aren't set yet (no config)
+    $index_id = '';
+    $index_entity = null;
+    $server = '';
+    
+    $has_index_config = !empty($ado_type_config->get('index_id'));
+    // If there is config, use the values
+    if ($has_index_config) {
+      $index_id = $ado_type_config->get('index_id');
+      // Get full index entity based on the index_id stored in config
+      $index_entity = $this->getIndex($index_id);
+      // use the built-in index entity method to get its server_id
+      $server = $index_entity->getServerId();
+    }
 
-    // Create a fieldset for the Type setting
-    $form['type'] = array(
+    // I couldn't find a better way to get this info into the form #states, because #states api for selects can only depend on the value of another element and don't work well with boolean value.
+    $form['servers-exist'] = [
+      '#type' => 'hidden',
+      '#prefix' => '<div id="servers-exist">',
+      '#suffix' => '</div>',
+      '#value' => empty($servers) ? null : 'servers'
+    ];
+    
+    // Create replacement fieldset in the case of no existing Solr Servers
+    $form['no-servers-message'] = [
       '#type' => 'fieldset',
-      '#title' => $this->t('Solr Field for Type in View Mode mapping'),
-      '#markup' => '<p>Choose the Solr field that will be used in our ADO to View Mode mapper. <br><br> Fields are specific to their Solr Server and Index. <br> To edit servers, indexes, and fields, visit <a href=" /admin/config/search/search-api/">Search API Config</a><br> For info and settings about the View Mode mapper, visit the <a href="/admin/config/archipelago/viewmode_mapping">ADO to View Mode Config</a></p>'
-    );
+      '#title' => $this->t('Source for Archipelago Digital Object Type'),
+      '#markup' => '<p>No existing Solr Servers. Please visit <a href=" /admin/config/search/search-api/">Search API Config</a> to set one up, and then return to this form.</p>',
+      '#states' => [
+        'invisible' => [
+          ':input[name="servers-exist"]' => ['value' => 'servers'],
+        ],
+      ],
+    ];
+    
+    // Create a fieldset for the ADO Type settings
+    $form['ado_type'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Source for Archipelago Digital Object Type'),
+      '#markup' => '<p>Choose the Solr field that determines an ADO\'s Type. Type is then used across Archipelago. <br><br> Fields are specific to their Solr Server and Index. <br> To edit servers, indexes, and fields, visit <a href=" /admin/config/search/search-api/">Search API Config</a><br> For info and settings about the View Mode mapper, visit the <a href="/admin/config/archipelago/viewmode_mapping">ADO to View Mode Config</a></p>',
+      '#states' => [
+        'visible' => [
+          ':input[name="servers-exist"]' => ['value' => 'servers'],
+        ],
+      ],
+    ];
 
-    $form['type']['server_select'] = [
+    $form['ado_type']['server_select'] = [
       '#type' => 'select',
       '#title' => $this->t('Step 1. Select Server'),
       '#options' => $this->formatOptions($servers),
-      '#default_value' => $config->get('type_server'),
+      '#default_value' => $server,
+      "#empty_value" => '',
+      '#empty_option' => '- Select Server -',
+      '#required' => TRUE,
       '#ajax' => [
         'callback' => '::onServerSelect',
         'disable-refocus' => FALSE,
         'event' => 'change',
         'wrapper' => 'index-select', 
-      ]
+      ],
     ];
     
-    $form['type']['index_select'] = [
+    $form['ado_type']['index_select'] = [
       '#type' => 'select',
       '#title' => $this->t('Step 2. Select Solr Index'),
       '#prefix' => '<div id="index-select">',
       '#suffix' => '</div>',
-      '#options' => $config->get('type_server') ? $this->getIndexes($config->get('type_server')) : null,
-      "#empty_value" => "",
-      "#default_value" => $config->get('type_index'),
+      '#options' => $has_index_config ? $this->getIndexes($server) : null,
+      "#default_value" => $index_id,
+      "#empty_value" => '',
+      '#empty_option' => '- Select Solr Index -',
       // If not #validated, dynamically populated dropdowns don't work.
       '#validated' => TRUE,
+      '#required' => TRUE,
       '#ajax' => [
         'callback' => '::onIndexSelect',
         'disable-refocus' => FALSE, 
         'event' => 'change',
         'wrapper' => 'solr-field-select', 
+      ],
+      '#states' => [
+        'visible' => [
+          ':input[name="server_select"]' => ['!value' => ''],
+        ],
       ]
     ];
     
-    $form['type']['solr_field_select'] = [
+    $form['ado_type']['solr_field_select'] = [
       '#type' => 'select',
       '#title' => $this->t('Step 3. Select Solr Field'),
       '#prefix' => '<div id="solr-field-select">',
       '#suffix' => '</div>',
-      '#options' => $config->get('type_server') && $config->get('type_index') ? $this->getSolrFields($config->get('type_index')) : null,
-      "#empty_value" => "",
-      "#default_value" => $config->get('type_field'),
+      '#options' => $has_index_config ? $this->getSolrFields($index_entity) : null,
+      "#default_value" => $ado_type_config->get('field'),
+      "#empty_value" => '',
+      '#empty_option' => '- Select Solr Field -',
       // If not #validated, dynamically populated dropdowns don't work.
       '#validated' => TRUE,
+      '#required' => TRUE,
+      '#states' => [
+        'visible' => [
+          ':input[name="server_select"]' => ['!value' => ''],
+        ],
+      ],
     ];
     
     return parent::buildForm($form, $form_state);
@@ -238,10 +319,9 @@ class ImportantSolrSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->config('strawberryfield.archipelago_solr_settings')
-      ->set('type_server', $form_state->getValue('server_select'))
-      ->set('type_index', $form_state->getValue('index_select'))
-      ->set('type_field', $form_state->getValue('solr_field_select'))
+    $this->config('strawberryfield.archipelago_solr_settings.ado_type')
+      ->set('index_id', $form_state->getValue('index_select'))
+      ->set('field', $form_state->getValue('solr_field_select'))
       ->save();
 
     parent::submitForm($form, $form_state);

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -138,7 +138,7 @@ class StrawberryfieldUtilityService {
     
     $sbf_solr_fields = array();
     
-    foreach ($solr_fields as $field) {
+    foreach ($solr_fields as $id => $field) {
       $property_path = explode(":", $field['property_path']);
       // use the first part of the property path (this will be the field machine name)
       $field_name = $property_path[0];
@@ -151,7 +151,7 @@ class StrawberryfieldUtilityService {
       $has_node_datasource = array_key_exists('datasource_id', $field) ? $field['datasource_id'] === "entity:node" : false;
 
       if ($has_sbf_property_path && $has_node_datasource) {
-        $sbf_solr_fields[] = $field;
+        $sbf_solr_fields[$id] = $field;
       }
     }
     

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -60,9 +60,14 @@ class StrawberryfieldUtilityService {
 
    */
   protected $entityFieldManager;
-  
-  // TODO phpdoc
-  protected $strawberryfieldMachineNames;
+
+  /**
+   * A list of Field names of type SBF
+   *
+   * @var array|NULL
+   *
+   */
+  protected $strawberryfieldMachineNames = NULL;
 
   public function __construct(
     FileSystemInterface $file_system,
@@ -113,6 +118,13 @@ class StrawberryfieldUtilityService {
    *  Returns array of names
    */
   public function getStrawberryfieldMachineNames() {
+    // Only NUll if not initialized. The moment this Service
+    // Gets constructed we set this data.
+    // @TODO. Do we want to calculate this expensive function
+    // everytime or just on demand?
+    if ($this->strawberryfieldMachineNames !== NULL) {
+      return $this->strawberryfieldMachineNames;
+    }
     $node_field_definitions = $this->entityFieldManager->getFieldStorageDefinitions('node');
     $sbf_field_names = array();
     foreach ($node_field_definitions as $field_definition) {

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -15,7 +15,7 @@ use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\file\FileInterface;
 use Drupal\Core\Entity\ContentEntityInterface;
-
+use Drupal\search_api\Entity\Index; 
 /**
  * Provides a SBF utility class.
  */
@@ -82,4 +82,29 @@ class StrawberryfieldUtilityService {
     }
     return $hassbf[$key];
   }
+
+  /**
+   * Checks whether the Solr Fields in a Solr Index are from SBFs
+   **
+   * @param Drupal\search_api\Entity\Index $index_entity
+   *
+   * @return array
+   *  Returns array of solr fields
+   */
+  public function getStrawberryfieldSolrFields(Index $index_entity) {
+    $solr_fields = $index_entity->get('field_settings');
+    $sbf_solr_fields = array();
+
+    foreach ($solr_fields as $field) {
+      $property_path = explode(":", $field['property_path']);
+      $has_sbf_property_path = in_array('field_descriptive_metadata', $property_path);
+      $has_node_datasource = array_key_exists('datasource_id', $field) ? $field['datasource_id'] === "entity:node" : false;
+      if ($has_sbf_property_path && $has_node_datasource) {
+        $sbf_solr_fields[] = $field;
+      }
+    }
+    
+    return $sbf_solr_fields;
+  }
 }
+

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -11,6 +11,7 @@ namespace Drupal\strawberryfield;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\file\FileInterface;
@@ -38,22 +39,44 @@ class StrawberryfieldUtilityService {
   protected $entityTypeManager;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+
+   */
+  protected $configFactory;
+
+  /**
    * The Module Handler.
    *
    * @var \Drupal\Core\Extension\ModuleHandlerInterface;
    */
   protected $moduleHandler;
 
+  /**
+   * The Entity field manager service
+   *
+   * @var \Drupal\Core\Entity\EntityFieldManagerInterface $entityFieldManager;
+
+   */
+  protected $entityFieldManager;
+  
+  // TODO phpdoc
+  protected $strawberryfieldMachineNames;
+
   public function __construct(
     FileSystemInterface $file_system,
     EntityTypeManagerInterface $entity_type_manager,
     ConfigFactoryInterface $config_factory,
-    ModuleHandlerInterface $module_handler
+    ModuleHandlerInterface $module_handler,
+    EntityFieldManagerInterface $entity_field_manager
   ) {
     $this->fileSystem = $file_system;
     $this->entityTypeManager = $entity_type_manager;
-    $this->configfactory = $config_factory;
+    $this->configFactory = $config_factory;
     $this->moduleHandler = $module_handler;
+    $this->entityFieldManager = $entity_field_manager;
+    $this->strawberryfieldMachineNames = $this->getStrawberryfieldMachineNames();
   }
 
   /**
@@ -84,21 +107,49 @@ class StrawberryfieldUtilityService {
   }
 
   /**
-   * Checks whether the Solr Fields in a Solr Index are from SBFs
-   **
-   * @param Drupal\search_api\Entity\Index $index_entity
+   * Returns a list of the machine names of all existing SBF fields
    *
    * @return array
-   *  Returns array of solr fields
+   *  Returns array of names
+   */
+  public function getStrawberryfieldMachineNames() {
+    $node_field_definitions = $this->entityFieldManager->getFieldStorageDefinitions('node');
+    $sbf_field_names = array();
+    foreach ($node_field_definitions as $field_definition) {
+      if ($field_definition->getType() === "strawberryfield_field") {
+        $sbf_field_names[] = $field_definition->getName();
+      }
+    }
+    
+    return $sbf_field_names;
+  }
+
+  /**
+   * Returns the Solr Fields in a Solr Index are from SBFs
+   **
+   * @param \Drupal\search_api\Entity\Index $index_entity
+   *
+   * @return array
+   *  Returns array of solr fields only including those from SBFs
    */
   public function getStrawberryfieldSolrFields(Index $index_entity) {
     $solr_fields = $index_entity->get('field_settings');
+    $property_path_is_sbf = array();
+    
     $sbf_solr_fields = array();
-
+    
     foreach ($solr_fields as $field) {
       $property_path = explode(":", $field['property_path']);
-      $has_sbf_property_path = in_array('field_descriptive_metadata', $property_path);
+      // use the first part of the property path (this will be the field machine name)
+      $field_name = $property_path[0];
+      // check if this $field_name exists as an sbf field name, and store result in $property_path_is_sbf
+      // check if key already exists, as there will be repeats among solr fields
+      if (!isset($property_path_is_sbf[$field_name])) {
+        $property_path_is_sbf[$field_name] = in_array($field_name, $this->strawberryfieldMachineNames);
+      }
+      $has_sbf_property_path = $property_path_is_sbf[$field_name];
       $has_node_datasource = array_key_exists('datasource_id', $field) ? $field['datasource_id'] === "entity:node" : false;
+
       if ($has_sbf_property_path && $has_node_datasource) {
         $sbf_solr_fields[] = $field;
       }
@@ -107,4 +158,3 @@ class StrawberryfieldUtilityService {
     return $sbf_solr_fields;
   }
 }
-

--- a/strawberryfield.links.menu.yml
+++ b/strawberryfield.links.menu.yml
@@ -21,3 +21,10 @@ strawberryfield.storage_settings_form:
   parent: strawberryfield.group.admin
   weight: 99
 
+strawberryfield.important_solr_settings_form:
+  title: 'Important Solr Settings Form'
+  route_name: strawberryfield.important_solr_settings_form
+  description: 'Configure which Solr field is used in ADO Type Mapping'
+  parent: strawberryfield.group.admin
+  weight: 99
+

--- a/strawberryfield.routing.yml
+++ b/strawberryfield.routing.yml
@@ -17,3 +17,13 @@ strawberryfield.storage_settings_form:
     _permission: 'access administration pages'
   options:
     _admin_route: TRUE
+
+strawberryfield.important_solr_settings_form:
+  path: '/admin/config/archipelago/important-solr-settings'
+  defaults:
+    _form: '\Drupal\strawberryfield\Form\ImportantSolrSettingsForm'
+    _title: 'Important Solr Settings'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -1,7 +1,7 @@
 services:
   strawberryfield.utility:
     class: Drupal\strawberryfield\StrawberryfieldUtilityService
-    arguments: [ '@file_system', '@entity_type.manager', '@config.factory','@module_handler']
+    arguments: [ '@file_system', '@entity_type.manager', '@config.factory','@module_handler', '@entity_field.manager']
 
   strawberryfield.file_persister:
     class: Drupal\strawberryfield\StrawberryfieldFilePersisterService


### PR DESCRIPTION
Addresses #53 

### Issue Summary
This push addresses the first part only of #53, creating the form to save the new config.

### What's changed?
- Add schema for strawberryfield.archipelago_solr_settings. For now it only holds type related config
- Add route to /admin/config/archipelago/important-solr-settings
- Add ImportantSolrSettingsForm.php
  This is the most code in this file. I don't know if it is the optimal UI, with multiple dropdowns, but it works pretty well for me.

### To Test
Go to /admin/config/archipelago/important-solr-settings and follow the form
I created extra Servers and Indexes to make sure all the conditional switching worked.

### Notes
Not sure how you want to deal with no config set. I am guessing, @DiegoPino since you were going to deal with the second part of #53 , that you might set default config.


