### PR TITLE
ISSUE-57: Add a schema for our SBF Flavor data source plugin

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -84,4 +84,36 @@ strawberryfield.archipelago_solr_settings.field_config:
     field:
       type: string
       label: 'Solr Field'
-      
+
+plugin.plugin_configuration.search_api_datasource.strawberryfield_flavor_datasource:
+  type: mapping
+  label: 'Strawberryfield Flavor datasource configuration'
+  mapping:
+    bundles:
+      type: mapping
+      label: 'Bundles bearing Strawberryfields'
+      mapping:
+        default:
+          type: boolean
+          label: 'Whether to exclude (TRUE) or include (FALSE) the selected bundles bearing a Strawberryfield.'
+        selected:
+          type: sequence
+          label: 'The selected bundles'
+          orderby: value
+          sequence:
+            type: string
+            label: 'A bundle machine name'
+    languages:
+      type: mapping
+      label: 'Languages'
+      mapping:
+        default:
+          type: boolean
+          label: 'Whether to exclude (TRUE) or include (FALSE) the selected languages.'
+        selected:
+          type: sequence
+          label: 'The selected languages'
+          orderby: value
+          sequence:
+            type: string
+            label: 'A language code'      


### PR DESCRIPTION
See #57 

# What is new?
This pull adds the basic configs needed for our SB Flavor Data Source Provider Plugin (Search API) to pass any configuration sync sanity (except mental) checks.

Nothing to see here. This supports this code https://github.com/esmero/strawberryfield/blob/8.x-1.0-beta2/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php#L451-L501

