### PR TITLE
ISSUE-55: Title setter Service based on Metadata 

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -84,4 +84,36 @@ strawberryfield.archipelago_solr_settings.field_config:
     field:
       type: string
       label: 'Solr Field'
-      
+
+plugin.plugin_configuration.search_api_datasource.strawberryfield_flavor_datasource:
+  type: mapping
+  label: 'Strawberryfield Flavour datasource configuration'
+  mapping:
+    bundles:
+      type: mapping
+      label: 'Bundles bearing Strawberryfields'
+      mapping:
+        default:
+          type: boolean
+          label: 'Whether to exclude (TRUE) or include (FALSE) the selected bundles bearing a Strawberryfield.'
+        selected:
+          type: sequence
+          label: 'The selected bundles'
+          orderby: value
+          sequence:
+            type: string
+            label: 'A bundle machine name'
+    languages:
+      type: mapping
+      label: 'Languages'
+      mapping:
+        default:
+          type: boolean
+          label: 'Whether to exclude (TRUE) or include (FALSE) the selected languages.'
+        selected:
+          type: sequence
+          label: 'The selected languages'
+          orderby: value
+          sequence:
+            type: string
+            label: 'A language code'

--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -65,7 +65,7 @@ strawberryfield.storage_settings:
     object_file_scheme:
       type: string
       label: 'Storage Scheme for Persisting Digital Objects in JSON format'
-      
+
 strawberryfield.archipelago_solr_settings:
   type: config_object
   label: 'Important Solr Settings for Archipelago'
@@ -73,7 +73,7 @@ strawberryfield.archipelago_solr_settings:
     ado_type:
       type: strawberryfield.archipelago_solr_settings.field_config
       label: 'Source for Archipelago Digital Object Type'
-      
+
 strawberryfield.archipelago_solr_settings.field_config:
   type: mapping
   label: 'Field Config for Archipelago Solr Settings'
@@ -87,7 +87,7 @@ strawberryfield.archipelago_solr_settings.field_config:
 
 plugin.plugin_configuration.search_api_datasource.strawberryfield_flavor_datasource:
   type: mapping
-  label: 'Strawberryfield Flavour datasource configuration'
+  label: 'Strawberryfield Flavor datasource configuration'
   mapping:
     bundles:
       type: mapping

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Component\Utility\Unicode;
+
+
+/**
+ * Event subscriber for SBF bearing entity presave event.
+ */
+class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends StrawberryfieldEventPresaveSubscriber {
+
+  use StringTranslationTrait;
+
+  /**
+   * @var int
+   */
+  protected static $priority = -900;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+
+  /**
+   * The Storage Destination Scheme.
+   *
+   * @var string;
+   */
+  protected $destinationScheme = NULL;
+
+  /**
+   * StrawberryfieldEventPresaveSubscriberFilePersister constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger,
+    LoggerChannelFactoryInterface $logger_factory
+
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+    $this->loggerFactory = $logger_factory;
+  }
+
+
+  /**
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function onEntityPresave(StrawberryfieldCrudEvent $event) {
+
+    /* @var $entity \Drupal\Core\Entity\ContentEntityBase */
+    $entity = $event->getEntity();
+    $sbf_fields = $event->getFields();
+    $titleadded = NULL;
+    $forceupdate = TRUE;
+    if (!$entity->isNew()) {
+      if ($entity->original->getTitle() != $entity->getTitle()) {
+        // Means someone manually, via a Title Widget, changed the title
+        // If so, enforce that and don't try to overwrite.
+        // But, weform widget, if updating title automatically is set, will
+        // Unset the ->title, allowing us to always get metadata title into
+        // the node one. Still, allowing other widgets to set titles without us
+        // overriding it. Smart?
+        $forceupdate = FALSE;
+      }
+    }
+
+    if (!$entity->getTitle() || $forceupdate) {
+      foreach ($sbf_fields as $field_name) {
+        /* @var $field \Drupal\Core\Field\FieldItemInterface */
+        $field = $entity->get($field_name);
+        /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+        // This will try with any possible match.
+        foreach ($field->getIterator() as $delta => $itemfield) {
+          $flat = $itemfield->provideFlatten();
+          if (isset($flat['label'])) {
+            // Flattener should always give me an array?
+            if (is_array($flat['label'])) {
+              $title = reset($flat['label']);
+            }
+            else {
+              $title = $flat['label'];
+            }
+            if (strlen(trim($title)) > 0) {
+              $title = Unicode::truncate($title,128,TRUE,TRUE, 24);
+              $entity->setTitle($title);
+              $titleadded = $title;
+              break 2;
+            }
+          }
+        }
+      }
+      if ($titleadded) {
+        $this->messenger->addStatus(
+          $this->t(
+            'Your New Object title is @title',
+            ['@title' => $titleadded ]
+          )
+        );
+      } else {
+        // Means we need a title, got nothing from metadata or node, dealing with it.
+        $title = $this->t('New Untitled Archipelago Digital Object by @author', ['@author' => $entity->getOwner()->getDisplayName()]);
+        $entity->setTitle($title);
+      }
+      $current_class = get_called_class();
+      $event->setProcessedBy($current_class, TRUE);
+    }
+  }
+}

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
@@ -74,10 +74,11 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
       if ($entity->original->getTitle() != $entity->getTitle()) {
         // Means someone manually, via a Title Widget, changed the title
         // If so, enforce that and don't try to overwrite.
-        // But, weform widget, if updating title automatically is set, will
-        // Unset the ->title, allowing us to always get metadata title into
+        // But, webform widget, if updating title automatically is set, should
+        // unset the 'title', allowing us to always get metadata title into
         // the node one. Still, allowing other widgets to set titles without us
         // overriding it. Smart?
+        // Reality is, if you don't use Title, just leave it out.
         $forceupdate = FALSE;
       }
     }

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -26,6 +26,11 @@ services:
     tags:
       - {name: event_subscriber}
     arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister']
+  strawberryfield.presavesetlabelfrommetadata_subscriber:
+     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata
+     tags:
+       - {name: event_subscriber}
+     arguments: ['@string_translation', '@messenger','@logger.factory']
   strawberryfield.insertdeposit_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventInsertSubscriberDepositDO
     tags:


### PR DESCRIPTION
See #55 

# What is new?

This adds a quite naive service that allows Nodes without a visible Title Field during Ingest to use a SBF 'label' key as Title for the node, avoiding also the fact that Drupal 8 totally allows you to hide the field but knows little what to do after the fact and dies with a shiny white page with constraints failures (or course, since title is a primary entity key).

We also, smartly truncate the SBF label, a.k.a title since Drupal's Title field length by default is 128 Chars and that is not really enough for metadata, right people? Means, our Metadata title will always be richer and cooler.

Anyway. We also provide (since we are here) our SBF Flavor Datasource Schema, which was missing or really, was == as any other Content Data source == and was already commited in #57, but i was working on both at the same time and faster than rebasing at this stage.

This will get merged right away and i will deal with other further improvements, like 
TODO: add a setting somewhere, with a warning, where people can select which JSON key will provide the Title for the ADO/NODE. If i do this, Changing  that setting /the/fact is a bad idea, but we should allow people to make bad decisions.

@mitchellkeaney @marlo-longley @giancarlobi just letting you know this is happening.


