### PR TITLE
ISSUE-60: Automatic Natural order for uploaded files

### DIFF
--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -407,6 +407,20 @@ class StrawberryfieldFilePersisterService {
         // @TODO see if having the same file in different keys is even
         // a good idea.
       }
+      // Natural Order Sort.
+      // @TODO how should we deal with manually ordered files?
+      // This will always reorder everything based on filenames.
+      uasort($fileinfo_bytype_many['as:' . $askey], array($this,'sortByFileName'));
+      // For each always wins over array_walk
+      $i=0;
+      foreach ($fileinfo_bytype_many['as:' . $askey] as &$item) {
+        $i++;
+       //Order is already given by uasort but not trustable in JSON
+       //So we set sequence number
+        $item['sequence'] = $i;
+      }
+
+
     }
 
     return $fileinfo_bytype_many;
@@ -773,4 +787,30 @@ class StrawberryfieldFilePersisterService {
     }
     return $success;
   }
+
+  /**
+   * Natural Sort function to be used as uasort callback
+   *
+   * Only works for as: structures like
+   *  $fileinfo = [
+   *  'type' => ucfirst($askey),
+   *  'url' => $destinationuri,
+   *  'crypHashFunc' => 'md5',
+   *  'checksum' => $md5,
+   *  'dr:for' => $file_source_key,
+   *  'dr:fid' => (int) $file->id(),
+   *  'dr:uuid' => $uuid,
+   *  'name' => $file->getFilename(),
+   *  'tags' => [],
+  ];
+
+   * @param $a
+   * @param $b
+   *
+   * @return int
+   */
+  public function sortByFileName($a, $b) {
+    return strnatcmp($a['name'],$b['name']);
+  }
+
 }

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -802,8 +802,7 @@ class StrawberryfieldFilePersisterService {
    *  'dr:uuid' => $uuid,
    *  'name' => $file->getFilename(),
    *  'tags' => [],
-  ];
-
+   * ];
    * @param $a
    * @param $b
    *


### PR DESCRIPTION
See #60 

This is a quite simplistic automatic sequencer (🎧...not that type of sequences) based on natural ordering of file names that lives on our File Persister Service. It will always kick in on Edit/Ingest, so we need to come up with solutions that don't interfere with forcer/manual ordering, if that is the case. It just adds a `sequence` key to our `as:filetype` JSON structure and its corresponding value after an `uasort` using natural string comparison.

I just came (while writing this) with two additional ideas, additional (and not excluding) to the ToC  (Table of Content or index) and the _'i don't know what i'm doing_' 🙄 i stated in the issue:

1.- If the current order, is already _totally not_ in Natural Order, but `sequence` keys with values are present, when assume its manually ordered. So to force an automatic ordering we just would need a function that removes all sequence keys.
2.- Allow people to use the fact that we are automatic ordering by making changing the File `name` key. It does not affect how the file is really named and stored in the DB or in local storage, `min.io` or AWS S3 (we already use the UUID right?), but will kick immediately a reorder on save. This change is actually just cosmetic. This also is end user experience consistent, assuming we could want allow people to download, e.g a Page, and with this the name of the file would be consistent with the order of display. I see fifth Page, i want to download that file, i get a name that makes sense in the context of the digital Object.