### PR TITLE
Issue-11: Allow denormalizing of encoded JSON in Strawberryfields

### DIFF
--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -438,4 +438,16 @@ class StrawberryfieldJsonHelper {
       }
     );
   }
+  
+  /** Test if an input is a valid JSON string.
+   * 
+   * @param $input
+   *
+   * @return boolean 
+   */
+  public static function isJsonString($input) {
+    
+    return is_string($input) && is_array(json_decode($input, true)) && (json_last_error() == JSON_ERROR_NONE);
+  }
+  
 }


### PR DESCRIPTION
This addresses #11 

### What is new?

Not much code. It took me some studying to understand this system in Drupal. The best article I read was [here](https://www.dx-experts.nl/en/blog/2017/drupal-8-hal-json-rest-mechanisms) even though it is specifically about hal json.

Now we can accept expanded JSON content in an SBF via POST, and create a valid new Node bearing the SBF. POST can accept either stringified or expanded JSON for SBF.


#### Testing Steps.

This section will look really long, because of pasted-in JSON. But it is not actually scary.

1. Clear cache because we have new services. Then go to `/admin/config/services/rest`. Make sure POST is enabled for node and enable the format `hal_json`. 

2. Below is a big old JSON taken from our minio storage. I was encountering permission problems creating new nodes, for the purposes of this Issue I simplified the object and removed everything on the node except for `title` and `field_descriptive_metadata`. One thing to note is the `_links` field. This is required by hal_json format. hal_json is the format I think we will be using because it can resolve relations between Drupal entities like files and images with uuids. So. If you want to do a big huge `curl` you use this (replace username:password, and token. You can get token from `http://localhost:8001/session/token`):

```

curl --include \
--request POST \
--user <username>:<password> \
--header 'Content-type: application/hal+json' \
--header 'X-CSRF-Token: <token>' \
http://localhost:8001/node\?_format\=hal_json \
--data-binary '{
"_links": {
"type": {
"href": "http://localhost:8001/rest/type/node/digital_object"
}
},
"title":[{"value":"REST ADO - test expanded JSON"}],
"field_descriptive_metadata": [
{
"value": {
"type": "Photograph",
"label": "Base ADO",
"owner": "Marlo",
"audios": null,
"images": [
30
],
"models": null,
"videos": null,
"hotspot": [],
"as:image": {
"urn:uuid:2b4fd124-ae6f-48c0-a7dd-2fd85a1b6cd2": {
"url": "s3://935/image-kite-1-2b4fd124-ae6f-48c0-a7dd-2fd85a1b6cd2.jpg",
"name": "kite_1.jpg",
"tags": [],
"type": "Image",
"dr:fid": 30,
"dr:for": "images",
"dr:uuid": "2b4fd124-ae6f-48c0-a7dd-2fd85a1b6cd2",
"checksum": "9358de99f051ae4ea44493b95f17e23b",
"crypHashFunc": "md5"
}
},
"documents": null,
"edm_agent": [
{
"name_uri": "http://example.com/marlo",
"role_uri": "",
"name_label": "Marlo",
"role_label": ""
}
],
"nominatim": {
"lat": "-102.4107493",
"lng": "34.2331373",
"city": "Earth",
"state": "Texas",
"value": "Earth, Lamb County, Texas, United States of America",
"county": "Lamb County",
"osm_id": "6595891",
"country": "United States of America",
"category": "place",
"locality": "",
"osm_type": "relation",
"postcode": "",
"country_code": "us",
"display_name": "Earth, Lamb County, Texas, United States of America",
"neighbourhood": "",
"state_district": ""
},
"ismemberof": null,
"description": "A photograph of a cool old-timey kite.",
"subject_loc": [
{
"uri": "http://id.loc.gov/authorities/subjects/sh85072580",
"label": "Kites"
}
],
"as:generator": {
"type": "Create",
"actor": {
"url": "http://localhost:8001/form/descriptive-metadata",
"name": "descriptive_metadata",
"type": "Service"
},
"endTime": "2020-01-26T22:30:23-05:00",
"summary": "Generator",
"@context": "https://www.w3.org/ns/activitystreams"
},
"date_published": "2020-01-26",
"term_aat_getty": {
"uri": "http://vocab.getty.edu/aat/300218777",
"label": "kites (equipment)"
},
"ap:entitymapping": {
"entity:file": [
"images",
"documents",
"audios",
"videos",
"models"
]
},
"geographic_place": "Earth",
"local_identifier": "kite001",
"subject_wikidata": [
{
"uri": "http://www.wikidata.org/entity/Q42861",
"label": "kite "
}
],
"strawberry_field_widget_id": "descriptive_metadata",
"strawberry_field_widget_source_entity_id": null,
"strawberry_field_widget_source_entity_uuid": ""
},
"str_flatten_keys": [
"type",
"label",
"owner",
"audios",
"images.[*]",
"models",
"videos",
"as:image.*.url",
"as:image.*.name",
"as:image.*.type",
"as:image.*.dr:fid",
"as:image.*.dr:for",
"as:image.*.dr:uuid",
"as:image.*.checksum",
"as:image.*.crypHashFunc",
"documents",
"edm_agent.[*].name_uri",
"edm_agent.[*].role_uri",
"edm_agent.[*].name_label",
"edm_agent.[*].role_label",
"nominatim.lat",
"nominatim.lng",
"nominatim.city",
"nominatim.state",
"nominatim.value",
"nominatim.county",
"nominatim.osm_id",
"nominatim.country",
"nominatim.category",
"nominatim.locality",
"nominatim.osm_type",
"nominatim.postcode",
"nominatim.country_code",
"nominatim.display_name",
"nominatim.neighbourhood",
"nominatim.state_district",
"ismemberof",
"description",
"subject_loc.[*].uri",
"subject_loc.[*].label",
"as:generator.type",
"as:generator.actor.url",
"as:generator.actor.name",
"as:generator.actor.type",
"as:generator.endTime",
"as:generator.summary",
"as:generator.@context",
"date_published",
"term_aat_getty.uri",
"term_aat_getty.label",
"ap:entitymapping.entity:file.[*]",
"geographic_place",
"local_identifier",
"subject_wikidata.[*].uri",
"subject_wikidata.[*].label",
"strawberry_field_widget_id",
"strawberry_field_widget_source_entity_id",
"strawberry_field_widget_source_entity_uuid"
]}]
}'
```
OK. You now have a new ADO. You can view it. You can “Edit” it in a webform and see all the field_descriptive_metadata properly filling out the form fields, including Nominatim, Linked Data, etc.

You might want to test POSTing a node where the SBF is not expanded. Here is another huge curl you can use for testing that:

```
curl --include \
--request POST \
--user <username>:<password> \
--header 'Content-type: application/hal+json' \
--header 'X-CSRF-Token: <token>' \
http://localhost:8001/node\?_format\=hal_json \
--data-binary '{
"_links": {
"type": {
"href": "http://localhost:8001/rest/type/node/digital_object"
}
},
"title":[{"value":"REST ADO - test string JSON"}],
"field_descriptive_metadata": [
{
"value": "{\"type\": \"Photograph\", \"label\": \"Base ADO\", \"owner\": \"Marlo\", \"audios\": null, \"images\": [30], \"models\": null, \"videos\": null, \"hotspot\": [], \"as:image\": {\"urn:uuid:2b4fd124-ae6f-48c0-a7dd-2fd85a1b6cd2\": {\"url\": \"s3://935/image-kite-1-2b4fd124-ae6f-48c0-a7dd-2fd85a1b6cd2.jpg\", \"name\": \"kite_1.jpg\", \"tags\": [], \"type\": \"Image\", \"dr:fid\": 30, \"dr:for\": \"images\", \"dr:uuid\": \"2b4fd124-ae6f-48c0-a7dd-2fd85a1b6cd2\", \"checksum\": \"9358de99f051ae4ea44493b95f17e23b\", \"crypHashFunc\": \"md5\"}}, \"documents\": null, \"edm_agent\": [{\"name_uri\": \"http://example.com/marlo\", \"role_uri\": \"\", \"name_label\": \"Marlo\", \"role_label\": \"\"}], \"nominatim\": {\"lat\": \"-102.4107493\", \"lng\": \"34.2331373\", \"city\": \"Earth\", \"state\": \"Texas\", \"value\": \"Earth, Lamb County, Texas, United States of America\", \"county\": \"Lamb County\", \"osm_id\": \"6595891\", \"country\": \"United States of America\", \"category\": \"place\", \"locality\": \"\", \"osm_type\": \"relation\", \"postcode\": \"\", \"country_code\": \"us\", \"display_name\": \"Earth, Lamb County, Texas, United States of America\", \"neighbourhood\": \"\", \"state_district\": \"\"}, \"ismemberof\": null, \"description\": \"A photograph of a cool old-timey kite.\", \"subject_loc\": [{\"uri\": \"http://id.loc.gov/authorities/subjects/sh85072580\", \"label\": \"Kites\"}], \"as:generator\": {\"type\": \"Create\", \"actor\": {\"url\": \"http://localhost:8001/form/descriptive-metadata\", \"name\": \"descriptive_metadata\", \"type\": \"Service\"}, \"endTime\": \"2020-01-26T22:30:23-05:00\", \"summary\": \"Generator\", \"@context\": \"https://www.w3.org/ns/activitystreams\"}, \"date_published\": \"2020-01-26\", \"term_aat_getty\": {\"uri\": \"http://vocab.getty.edu/aat/300218777\", \"label\": \"kites (equipment)\"}, \"ap:entitymapping\": {\"entity:file\": [\"images\", \"documents\", \"audios\", \"videos\", \"models\"]}, \"geographic_place\": \"Earth\", \"local_identifier\": \"kite001\", \"subject_wikidata\": [{\"uri\": \"http://www.wikidata.org/entity/Q42861\", \"label\": \"kite \"}], \"strawberry_field_widget_id\": \"descriptive_metadata\", \"strawberry_field_widget_source_entity_id\": null, \"strawberry_field_widget_source_entity_uuid\": \"\"}",
"str_flatten_keys": [
"type",
"label",
"owner",
"audios",
"images.[*]",
"models",
"videos",
"as:image.*.url",
"as:image.*.name",
"as:image.*.type",
"as:image.*.dr:fid",
"as:image.*.dr:for",
"as:image.*.dr:uuid",
"as:image.*.checksum",
"as:image.*.crypHashFunc",
"documents",
"edm_agent.[*].name_uri",
"edm_agent.[*].role_uri",
"edm_agent.[*].name_label",
"edm_agent.[*].role_label",
"nominatim.lat",
"nominatim.lng",
"nominatim.city",
"nominatim.state",
"nominatim.value",
"nominatim.county",
"nominatim.osm_id",
"nominatim.country",
"nominatim.category",
"nominatim.locality",
"nominatim.osm_type",
"nominatim.postcode",
"nominatim.country_code",
"nominatim.display_name",
"nominatim.neighbourhood",
"nominatim.state_district",
"ismemberof",
"description",
"subject_loc.[*].uri",
"subject_loc.[*].label",
"as:generator.type",
"as:generator.actor.url",
"as:generator.actor.name",
"as:generator.actor.type",
"as:generator.endTime",
"as:generator.summary",
"as:generator.@context",
"date_published",
"term_aat_getty.uri",
"term_aat_getty.label",
"ap:entitymapping.entity:file.[*]",
"geographic_place",
"local_identifier",
"subject_wikidata.[*].uri",
"subject_wikidata.[*].label",
"strawberry_field_widget_id",
"strawberry_field_widget_source_entity_id",
"strawberry_field_widget_source_entity_uuid"
]
}]
}'
```
