### PR TITLE
ISSUE-61: Make orderSequence a Static method of StrawberryfieldJsonHelper

### DIFF
--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -17,10 +17,21 @@ use JmesPath\Env as JmesPath;
  * @package Drupal\strawberryfield\Tools
  */
 class StrawberryfieldJsonHelper {
+  /**
+   * Defines all types of keys we generated based on file types.
+   */
+  const AS_FILE_TYPE = [
+    'as:image',
+    'as:document',
+    'as:video',
+    'as:audio',
+    'as:application',
+    'as:text'
+  ];
 
   /**
-* Defines a minimal JSON-LD context.
-*/
+   * Defines a minimal JSON-LD context.
+   */
   CONST SIMPLE_JSONLDCONTEXT = '{
     "@context":  {
        "type": "@type",
@@ -392,5 +403,39 @@ class StrawberryfieldJsonHelper {
     // If we check for : or @ or ! we would be doing a lot of
     // Extra processing when JMESPATH loves already double quotes.
     return '"' . $string . '"';
+  }
+
+  /**
+   * Sort an array by reference based on a sequence key integer.
+   *
+   * @param array $jsondata
+   *    Full JSON data, e.g, from a SBF value, as an array.
+   * @param string $mainkey
+   *    The Key we want to sort
+   * @param string $orderkey
+   *    The associative Array key used to compare order
+   */
+  public static function orderSequence(
+    array &$jsondata,
+    $mainkey = 'as:image',
+    $orderkey = 'sequence'
+  ) {
+    if (!isset($jsondata[$mainkey])) {
+      return;
+    }
+    uasort(
+      $jsondata[$mainkey],
+      function ($a, $b) use ($orderkey) {
+        if ((array_key_exists($orderkey, $a)) && (array_key_exists(
+            $orderkey,
+            $b
+          ))) {
+          return (int) $a[$orderkey] <=> (int) $b[$orderkey];
+        }
+        else {
+          return 0;
+        }
+      }
+    );
   }
 }


### PR DESCRIPTION
# Whats new? 

Move Array ordering/sorting out of formatter into a static method in our JSON helper class.

https://github.com/esmero/format_strawberryfield/pull/41 introduced a bug (because not every formatter extends our base formatter and i'm sleeping) so a good opportunity to also make that one better by moving this function totally out of our formatter.

Been giving the thought that the SBF field itself could expose a computed property that orders and decodes the JSON string into an array, maybe for Beta3



