### PR TITLE
ISSUE-69: Fix title setter, add some conditionals to deal with edge cases

### DIFF
--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
@@ -71,7 +71,8 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
     $titleadded = NULL;
     $forceupdate = TRUE;
     if (!$entity->isNew()) {
-      if ($entity->original->getTitle() != $entity->getTitle()) {
+      // Check if we had a title, if the new one is different and not empty.
+      if (($entity->original->getTitle() != $entity->label()) && !empty($entity->label())) {
         // Means someone manually, via a Title Widget, changed the title
         // If so, enforce that and don't try to overwrite.
         // But, webform widget, if updating title automatically is set, should
@@ -83,7 +84,7 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
       }
     }
 
-    if (!$entity->getTitle() || $forceupdate) {
+    if (!$entity->label() || $forceupdate) {
       foreach ($sbf_fields as $field_name) {
         /* @var $field \Drupal\Core\Field\FieldItemInterface */
         $field = $entity->get($field_name);
@@ -116,9 +117,15 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
           )
         );
       } else {
-        // Means we need a title, got nothing from metadata or node, dealing with it.
-        $title = $this->t('New Untitled Archipelago Digital Object by @author', ['@author' => $entity->getOwner()->getDisplayName()]);
-        $entity->setTitle($title);
+        // But maybe its just not in our metadata or someone forget to set a label key. Don't try to add it if so
+        if (!$entity->label()) {
+          // Means we need a title, got nothing from metadata or node, dealing with it.
+          $title = $this->t(
+            'New Untitled Archipelago Digital Object by @author',
+            ['@author' => $entity->getOwner()->getDisplayName()]
+          );
+          $entity->setTitle($title);
+        }
       }
       $current_class = get_called_class();
       $event->setProcessedBy($current_class, TRUE);


### PR DESCRIPTION
See #69 

# What is new?

While testing Beta2 i saw some inconsistencies while setting the ADO/NODE label when the Webform itself had the Title Label hidden (like we do in our default Webform for the deployment) and the Main Node title element was visible. That triggered on a first ingest an edge case where there was actually a title and none in the metadata and we ended with our default, save the queen, version of a generic title. This tiny pull fixes that. Tested with
1. Form mode with NODE title visible and webform Title invisible
  - Create
  - Edit
2. Form mode with NODE title invisible and webform Title invisible
  - Create
  - Edit 
3. Form mode with NODE title invisible and webform Title visible
  - Create
  - Edit
4. Form mode with NODE title visible and webform Title visible
  - Create
  - Edit

In all cases i got what i wanted. The title the user actually wanted to set or update (given the options we expose, no mind reading of course). Or in the case of 2. A fully generic but valid Title with the Object type, the Metadata Type and the User in the title.

I decided to go for $entity->label() instead of getTitle because of the chances of possible caching that could be involved in the getTitle version. I kept it for the ->original (in case of an edit has the data that was there before an edit happened) because i expect that one to be cached, always.

Anyone knows actually what the difference of both methods is? Could not find code to corroborate.

@marlo-longley @giancarlobi no need to test. I already did that for you. Will just go and merge. 


