### PR TITLE
Issue-71b: Add schema for strawberryfield_field itself!

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -127,3 +127,10 @@ field.widget.settings.strawberry_textarea:
     rows:
       type: string
       label: 'Rows'
+field.value.strawberryfield_field:
+  type: mapping
+  label: 'Strawberryfield value'
+  mapping:
+    value:
+      type: string
+      label: 'Strawvberry Metadata'


### PR DESCRIPTION
This addresses #71 (as did #72)
@DiegoPino I found more schema errors relating for this module :)

This fixes the missing schema error for 
`default_value.0.value` in `field.field.node.digital_object_collection.field_descriptive_metadata` (or any other field of type strawberryfield_field)

## What's new?
New schema in `config/schema/strawberryfield.schema.yml`

According to my searching, this missing schema seems to be a common error when creating custom field types in Drupal, so don't forget to add it next time :)

 
