### PR TITLE
Issue-74: Add theme suggestions for Strawberryfield nodes

### DIFF
--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -259,3 +259,47 @@ function strawberryfield_s3fs_url_settings_alter(array &$url_settings, $s3_file_
   //$account = Drupal::currentUser();
   //$url_settings['custom_GET_args']['x-user'] = $account->getAccountName();
 }
+
+/**
+ * Implements hook_theme_suggestions_HOOK_alter() for node templates.
+ * @param array $suggestions
+ * @param array $variables
+ */
+function strawberryfield_theme_suggestions_page_alter(array &$suggestions, array $variables) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+  $sbf = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($node);
+  if ($node instanceof \Drupal\node\NodeInterface && $sbf ) {
+    // Use _ for - and __ for -- in filenames
+    // Add general Strawberryfield theme hook
+    $suggestions[] = 'page__node__strawberryfield';
+    // Get the JSON
+    // TODO what if there are more than 1 sbf fields?
+    $sbfJson = Json::decode($node->get($sbf[0])->value);
+    foreach ($sbfJson as $key => $value) {
+      if (starts_with($key, 'as:')) {
+        switch ($key) {
+          case 'as:image':
+            $suggestions[] = 'page__node__strawberryfield__image';
+            break;
+          case 'as:model':
+            $suggestions[] = 'page__node__strawberryfield__3D_model';
+            break;
+          case 'as:video':
+            $suggestions[] = 'page__node__strawberryfield__video';
+            break;
+          case 'as:audio':
+            $suggestions[] = 'page__node__strawberryfield__audio';
+            break;
+          case 'as:application':
+            $suggestions[] = 'page__node__strawberryfield__application';
+            break;
+          case 'as:text':
+            $suggestions[] = 'page__node__strawberryfield__text';
+            break;
+          default:
+            continue;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Addresses #74 

### What's new?

<img width="355" alt="Screen Shot 2020-02-24 at 9 16 00 AM" src="https://user-images.githubusercontent.com/1328900/75175777-d178a400-56e7-11ea-9c4a-3cface2e5227.png">

Add hook in `strawberryfield.module` to suggest theme templates for strawberryfield bearing nodes. 
1. Always adds `page--node--strawberryfield` if SBF is present
2. Also conditionally adds  `page--node--strawberryfield--<type>` e.g. `page--node--strawberryfield--image` based on the type `as:` keys of the node.

### How to Test

Turn on Twig template debugging in `sites/default/services.yml` and set `twig.config` debug key to true. Then refresh a node page and see the hooks.

@DiegoPino is this what you were thinking?
