### PR TITLE
ISSUE-80: Change self:: for static:: and adjust priorities

### DIFF
--- a/src/EventSubscriber/StrawberryfieldEventInsertSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventInsertSubscriber.php
@@ -12,12 +12,17 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 abstract class StrawberryfieldEventInsertSubscriber implements EventSubscriberInterface {
 
   /**
+   * @var int
+   */
+  protected static $priority = -700;
+
+  /**
    * {@inheritdoc}
    */
   public static function getSubscribedEvents() {
 
     // @TODO check event priority and adapt to future D9 needs.
-    $events[StrawberryfieldEventType::INSERT][] = ['onEntityInsert', 100];
+    $events[StrawberryfieldEventType::INSERT][] = ['onEntityInsert', static::$priority];
     return $events;
   }
 

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriber.php
@@ -23,7 +23,8 @@ abstract class StrawberryfieldEventPresaveSubscriber implements EventSubscriberI
     // Make sure we have access before everything else here since we want
     // Enrich our JSON before anything runs.
     // @TODO check event priority and adapt to future D9 needs.
-    $events[StrawberryfieldEventType::PRESAVE][] = ['onEntityPresave', self::$priority];
+    // Use late binding. Never use self:: or we will all get -800 in every class.
+    $events[StrawberryfieldEventType::PRESAVE][] = ['onEntityPresave', static::$priority];
     return $events;
   }
 

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
@@ -19,7 +19,7 @@ class StrawberryfieldEventPresaveSubscriberVocabCreator extends StrawberryfieldE
   /**
    * @var int
    */
-  protected static $priority = -700;
+  protected static $priority = -1000;
 
   /**
    * The messenger.


### PR DESCRIPTION
See #80 

# What is this?

Change `self::` for `static::` to allow late binding of properties in subclasses (sounds like subatomic physics.. but its not)

Rememer kids, the lower the number, the later in time the execution is pushed:
priority 1 runs before -2000

