### PR TITLE
ISSUE-84: Only notify user of Metadata driven title change if change is noticeable

### DIFF
--- a/src/EventSubscriber/StrawberryfieldEventDeleteFileUsageDeleter.php
+++ b/src/EventSubscriber/StrawberryfieldEventDeleteFileUsageDeleter.php
@@ -42,6 +42,11 @@ class StrawberryfieldEventDeleteFileUsageDeleter extends StrawberryfieldEventDel
    */
   protected $strawberryfilepersister;
 
+  /**
+   * The logger factory.
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
 
   /**
    * StrawberryfieldEventInsertFileUsageUpdater constructor.

--- a/src/EventSubscriber/StrawberryfieldEventInsertFileUsageUpdater.php
+++ b/src/EventSubscriber/StrawberryfieldEventInsertFileUsageUpdater.php
@@ -36,6 +36,12 @@ class StrawberryfieldEventInsertFileUsageUpdater extends StrawberryfieldEventIns
   protected $serializer;
 
   /**
+   * The logger factory.
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
    * The Strawberryfield File Persister Service
    *
    *  @var \Drupal\strawberryfield\StrawberryfieldFilePersisterService

--- a/src/EventSubscriber/StrawberryfieldEventInsertSubscriberDepositDO.php
+++ b/src/EventSubscriber/StrawberryfieldEventInsertSubscriberDepositDO.php
@@ -51,6 +51,11 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
    */
   protected $strawberryfilepersister;
 
+  /**
+   * The logger factory.
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
 
   /**
    * StrawberryfieldEventInsertSubscriberDepositDO constructor.

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberFilePersister.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberFilePersister.php
@@ -49,6 +49,11 @@ class StrawberryfieldEventPresaveSubscriberFilePersister extends Strawberryfield
    */
   protected $strawberryfilepersister;
 
+  /**
+   * The logger factory.
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
 
   /**
    * StrawberryfieldEventPresaveSubscriberFilePersister constructor.

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
@@ -39,6 +39,13 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
   protected $destinationScheme = NULL;
 
   /**
+   * The logger factory.
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+
+  /**
    * StrawberryfieldEventPresaveSubscriberFilePersister constructor.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
@@ -59,16 +66,12 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
 
   /**
    * @param \Drupal\strawberryfield\Event\StrawberryfieldCrudEvent $event
-   *
-   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
-   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function onEntityPresave(StrawberryfieldCrudEvent $event) {
 
-    /* @var $entity \Drupal\Core\Entity\ContentEntityBase */
+    /* @var $entity \Drupal\node\Entity\Node */
     $entity = $event->getEntity();
     $sbf_fields = $event->getFields();
-    $titleadded = NULL;
     $originallabel = NULL;
     $forceupdate = TRUE;
     if (!$entity->isNew()) {
@@ -94,6 +97,7 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
         // This will try with any possible match.
         foreach ($field->getIterator() as $delta => $itemfield) {
           $flat = $itemfield->provideFlatten();
+          // @TODO Should we allow which JSON key sets the label a setting?
           if (isset($flat['label'])) {
             // Flattener should always give me an array?
             if (is_array($flat['label'])) {
@@ -103,38 +107,28 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
               $title = $flat['label'];
             }
             if (strlen(trim($title)) > 0) {
-              $title = Unicode::truncate($title,128,TRUE,TRUE, 24);
+              $title = Unicode::truncate($title, 128, TRUE, TRUE, 24);
               // we could check if originallabel != from the new title
               // I feel safer assinging and checking only for the status.
               $entity->setTitle($title);
-              $titleadded = $title;
               break 2;
             }
           }
         }
       }
 
-      // Only notify the user if the title actually changed.
-      if (($titleadded) && ($originallabel != $titleadded)) {
-        $this->messenger->addStatus(
-          $this->t(
-            'Your New Object title is @title',
-            ['@title' => $titleadded ]
-          )
+      // If at this stage we have no entity label, but maybe its just not in our metadata,
+      // or someone forget to set a label key.
+      if (!$entity->label()) {
+        // Means we need a title, got nothing from metadata or node, dealing with it.
+        $title = $this->t(
+          'No New Untitled Archipelago Digital Object by @author',
+          ['@author' => $entity->getOwner()->getDisplayName()]
         );
-      } else {
-        // But maybe its just not in our metadata or someone forget to set a label key. Don't try to add it if so
-        if (!$entity->label()) {
-          // Means we need a title, got nothing from metadata or node, dealing with it.
-          $title = $this->t(
-            'New Untitled Archipelago Digital Object by @author',
-            ['@author' => $entity->getOwner()->getDisplayName()]
-          );
-          $entity->setTitle($title);
-        }
+        $entity->setTitle($title);
       }
-      $current_class = get_called_class();
-      $event->setProcessedBy($current_class, TRUE);
     }
+    $current_class = get_called_class();
+    $event->setProcessedBy($current_class, TRUE);
   }
 }

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
@@ -69,10 +69,12 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
     $entity = $event->getEntity();
     $sbf_fields = $event->getFields();
     $titleadded = NULL;
+    $originallabel = NULL;
     $forceupdate = TRUE;
     if (!$entity->isNew()) {
       // Check if we had a title, if the new one is different and not empty.
-      if (($entity->original->getTitle() != $entity->label()) && !empty($entity->label())) {
+      $originallabel = $entity->original->getTitle();
+      if (($originallabel != $entity->label()) && !empty($entity->label())) {
         // Means someone manually, via a Title Widget, changed the title
         // If so, enforce that and don't try to overwrite.
         // But, webform widget, if updating title automatically is set, should
@@ -102,6 +104,8 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
             }
             if (strlen(trim($title)) > 0) {
               $title = Unicode::truncate($title,128,TRUE,TRUE, 24);
+              // we could check if originallabel != from the new title
+              // I feel safer assinging and checking only for the status.
               $entity->setTitle($title);
               $titleadded = $title;
               break 2;
@@ -109,7 +113,9 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
           }
         }
       }
-      if ($titleadded) {
+
+      // Only notify the user if the title actually changed.
+      if (($titleadded) && ($originallabel != $titleadded)) {
         $this->messenger->addStatus(
           $this->t(
             'Your New Object title is @title',


### PR DESCRIPTION
# What is new?

Basically, don't tell the user everytime it saves a Node/ADO via a Webform that the title changed if its still the same. Mostly cosmetic, but was driving me insane. Also, if the change happened with an actual title field visible and not only driven by webform, don't notify the user because the Event Subscriber basically does nothing (sets Force Update to false and skips the logic, good)

@giancarlobi @mitchellkeaney this is just a heads up so you know i did this. Will merge later today