### PR TITLE
ISSUE-90: Final commits for D9 readiness/spiciness

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "drupal/core": "^8.8 || ^9",
         "ml/json-ld": "^1.1",
         "mtdowling/jmespath.php":"^2.5",
         "swaggest/json-schema":"^0.12.25",

--- a/src/Event/StrawberryfieldCrudEvent.php
+++ b/src/Event/StrawberryfieldCrudEvent.php
@@ -40,7 +40,7 @@ class StrawberryfieldCrudEvent extends Event {
    * @var array
    *
    */
-  private $processedby;
+  private $processedby = [];
 
   /**
    * Construct a new entity event.

--- a/src/Form/keyNameProviderEntityDeleteForm.php
+++ b/src/Form/keyNameProviderEntityDeleteForm.php
@@ -37,8 +37,7 @@ class keyNameProviderEntityDeleteForm extends EntityConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
-
-    drupal_set_message(
+    $this->messenger()->addMessage(
       $this->t('content @type: deleted @label.',
         [
           '@type' => $this->entity->bundle(),

--- a/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
@@ -61,7 +61,7 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
       $jmespath_array = array_map('trim', explode(',', $jmespaths));
       $jmespath_result = [];
       foreach ($jmespath_array as $jmespath) {
-        $jmespath_result[] = $item->searchPath($jmespath,FALSE);
+        $jmespath_result[] = $item->searchPath(trim($jmespath),FALSE);
       }
       $jmespath_result_to_expose = [];
 

--- a/src/Plugin/Field/FieldType/StrawberryFieldFileComputedItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldFileComputedItem.php
@@ -93,7 +93,7 @@ class StrawberryFieldFileComputedItem extends EntityReferenceItem {
         'target_type' => 'file',
         'display_field' => FALSE,
         'display_default' => FALSE,
-        'uri_scheme' => file_default_scheme(),
+        'uri_scheme' => \Drupal::config('system.file')->get('default_scheme')
       ] + parent::defaultStorageSettings();
   }
 

--- a/src/Plugin/StrawberryfieldKeyNameProviderInterface.php
+++ b/src/Plugin/StrawberryfieldKeyNameProviderInterface.php
@@ -9,7 +9,8 @@
 namespace Drupal\strawberryfield\Plugin;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Plugin\PluginWithFormsInterface;
-use Drupal\Component\Plugin\ConfigurablePluginInterface;
+use Drupal\Component\Plugin\ConfigurableInterface;
+use Drupal\Component\Plugin\DependentPluginInterface;
 
 /**
  * Defines and Interface for StrawberryfieldKeyNameProvider Plugins
@@ -18,7 +19,7 @@ use Drupal\Component\Plugin\ConfigurablePluginInterface;
  *
  * @package Drupal\strawberryfield\Plugin
  */
-interface StrawberryfieldKeyNameProviderInterface extends PluginInspectionInterface, PluginWithFormsInterface, ConfigurablePluginInterface{
+interface StrawberryfieldKeyNameProviderInterface extends PluginInspectionInterface, PluginWithFormsInterface, ConfigurableInterface, DependentPluginInterface{
 
 
   /**

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -1024,13 +1024,13 @@ class StrawberryfieldFilePersisterService {
       $output_exif = '';
       $output_fido = '';
       $result_exif = exec(
-        $exif_exec_path . ' -json -q -a -gps:all -Common "-gps*" -xmp:all  -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . escapeshellcmd($templocation),
+        $exif_exec_path . ' -json -q -a -gps:all -Common "-gps*" -xmp:all  -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . escapeshellarg($templocation),
         $output_exif,
         $status_exif
       );
 
       $result_fido = exec(
-        $fido_exec_path . ' ' . escapeshellcmd($templocation),
+        $fido_exec_path . ' ' . escapeshellarg($templocation),
         $output_fido,
         $status_fido
       );

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -228,9 +228,9 @@ class StrawberryfieldFilePersisterService {
         $current_uri,
         PATHINFO_EXTENSION
       );
-      $file_parts['destination_scheme'] = $this->fileSystem->uriScheme(
-        $file->getFileUri()
-      );
+      $file_parts['destination_scheme'] =  $this->streamWrapperManager
+        ->getScheme($current_uri);
+
       list($file_parts['destination_filetype'],) = explode(
         '/',
         $file->getMimeType()

--- a/strawberryfield.info.yml
+++ b/strawberryfield.info.yml
@@ -2,10 +2,9 @@ name: Strawberry Field
 description: Creates a field type that stores JSON and makes it available to other Drupal modules.
 package: Archipelago
 type: module
-core: 8.x
+core_version_requirement: ^8.8 || ^9
 php: 7.1
 dependencies:
-  - 'drupal:system (>= 8.7)'
   - 'drupal:user'
   - 'drupal:field'
   - 'drupal:serialization'

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -55,15 +55,16 @@ function strawberryfield_node_presave(ContentEntityInterface $entity) {
       $events = '';
       foreach($event->getProcessedBy() as $event_info) {
         $success = $event_info['success']? 'Successful' : 'Failure';
-        $events .= $event_info['class'].'=>'.$success.'\n\r>';
+        $events .= '<li>'.$event_info['class']. ' => '.$success.'</li>';
       }
+      $events_markup = \Drupal\Core\Render\Markup::create($events);
       \Drupal::logger('strawberryfield')->notice(
-        'ADO with UUID @uuid spent @time seconds on all presave event subscriber processing and max memory usage was @maxmem. Event Subscribers that run where the following <br> @events',
+        'ADO with UUID @uuid spent @time seconds on all presave event subscriber processing and max memory usage was @maxmem. <br> Event Subscribers that could run were the following: <br><ul>@events</ul>',
         [
           '@uuid' => $entity->uuid(),
           '@time' => $time,
           '@maxmem' => \Drupal::service('strawberryfield.utility')->formatBytes($max_memory, 2),
-          '@events' => $events,
+          '@events' => $events_markup,
         ]
       );
     }

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -32,11 +32,12 @@ function strawberryfield_node_presave(ContentEntityInterface $entity) {
     // When benchmark is enabled a simple but effective report will be found in the reports/logs
     if ($config->get('benchmark')) {
       $bench = TRUE;
+      $start_time = microtime(true);
     }
     // Introducing our newest development, the processing time stats!
     // Starting on PHP 7.3 we should use hrtime for docker and VMS.
     // https://www.php.net/manual/en/function.microtime.php
-    $start_time = microtime(true);
+
     //@TODO make bench simply an Event Method! That way we can measure every
     //Event by calling it and for new ones. Etc.
 
@@ -49,11 +50,15 @@ function strawberryfield_node_presave(ContentEntityInterface $entity) {
     if ($bench) {
       $end_time = microtime(TRUE);
       // Removed bsuc
-      $time = round($end_time, $start_time, 4);
+      $time = round($end_time - $start_time, 4);
       $max_memory = memory_get_peak_usage(TRUE);
-      $events = implode("\n\r",$event->getProcessedBy());
+      $events = '';
+      foreach($event->getProcessedBy() as $event_info) {
+        $success = $event_info['success']? 'Successful' : 'Failure';
+        $events .= $event_info['class'].'=>'.$success.'\n\r>';
+      }
       \Drupal::logger('strawberryfield')->notice(
-        'ADO with UUID @uuid spend @time in seconds on all presave event subscriber processing and max memory usage was @maxmem. Event Subscribers that run where the following <br> @events',
+        'ADO with UUID @uuid spent @time seconds on all presave event subscriber processing and max memory usage was @maxmem. Event Subscribers that run where the following <br> @events',
         [
           '@uuid' => $entity->uuid(),
           '@time' => $time,


### PR DESCRIPTION
See #90 

Most of this is just housekeeping, changing some deprecated calls, interfaces and legacy code to be D9 ready. Still, there is a confusing issue (not us, them) regarding Symfony >=4.3 and now Events are being dispatched that makes no sense to me.

So Symfony 4.3 moves Events to a new Interface. And then also changes how the dispatch is done (the order or arguments). I did the chances and of course all died. And then checked D9 and D9 is still using the old versions (can anyone confirm?) for both, even if they are on 4.4 already. So deprecated code??

Anyway. I managed to open an issue here: https://gitlab.com/drupalspoons/devel/-/issues/329 (and i also have now an account there... how many gosh)

- Since i was also doing housekeeping there is a small formatting fix for the benchmark log and a asymptomatic fix for escaping file names on exif and PRONOM. asymptomatic because we already sanitize filenames on storage/preservation, so escaping really is futile. But consistency is important 

@giancarlobi for your eyes
Helping hand, @bryjbrown you guys dispatch events? Is your code D9 ready?

