### PR TITLE
Issue 10c: Adds new XML to JSON processing strategy and a fix for Drush ap:

### DIFF
--- a/src/Commands/JsonApiDrushCommands.php
+++ b/src/Commands/JsonApiDrushCommands.php
@@ -459,7 +459,7 @@ JSON;
           '-H "Content-Disposition: attachment; filename=\"' . urlencode(
             $file->filename
           ) . '\""',
-          '--data-binary @' . $file->uri,
+          '--data-binary @"' . escapeshellarg($file->uri) .'"',
         ];
         if ($options['user'] && $options['password']) {
           $args = array_merge(

--- a/src/Commands/JsonApiDrushCommands.php
+++ b/src/Commands/JsonApiDrushCommands.php
@@ -470,7 +470,7 @@ JSON;
               $fileurlpost,
             ]
           );
-
+          $this->output()->writeln(implode(' ', $args));
           $process = Drush::process(implode(' ', $args));
           $process->mustRun();
           if ($process->getExitCode() == 0) {

--- a/src/Commands/JsonApiDrushCommands.php
+++ b/src/Commands/JsonApiDrushCommands.php
@@ -459,7 +459,7 @@ JSON;
           '-H "Content-Disposition: attachment; filename=\"' . urlencode(
             $file->filename
           ) . '\""',
-          '--data-binary @"' . escapeshellarg($file->uri) .'"',
+          '--data-binary @\"' . escapeshellarg($file->uri) .'\"',
         ];
         if ($options['user'] && $options['password']) {
           $args = array_merge(

--- a/src/Commands/JsonApiDrushCommands.php
+++ b/src/Commands/JsonApiDrushCommands.php
@@ -459,7 +459,7 @@ JSON;
           '-H "Content-Disposition: attachment; filename=\"' . urlencode(
             $file->filename
           ) . '\""',
-          '--data-binary @\"' . escapeshellarg($file->uri) .'\"',
+          '--data-binary @"' . $file->uri.'"',
         ];
         if ($options['user'] && $options['password']) {
           $args = array_merge(

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
@@ -131,6 +131,9 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
           $fullvalues = $itemfield->provideDecoded(TRUE);
           // SBF needs to have the entity mapping key
           // helper structure to keep elements that map to entities around
+          if (!is_array($fullvalues)) {
+            break;
+          }
           $fullvalues = $this->cleanUpEntityMappingStructure($fullvalues);
           // 'ap:entitymapping' will always exists of ::cleanUpEntityMappingStructure
           $entity_mapping_structure = $fullvalues['ap:entitymapping'];

--- a/src/Plugin/DataType/StrawberryKeysFromJson.php
+++ b/src/Plugin/DataType/StrawberryKeysFromJson.php
@@ -71,8 +71,9 @@ class StrawberryKeysFromJson extends ItemList {
       //@TODO deal with JSON exceptions as we have done before
 
       $flattened = [];
+      $blacklist = ['ap:importeddata.content'];
       $flattened = StrawberryfieldJsonHelper::arrayToFlatJsonPropertypaths(
-        $jsonArray
+        $jsonArray, '', $blacklist
       );
       $this->processed = array_keys($flattened);
       $this->computed = TRUE;

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -129,7 +129,7 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements Pl
     // @TODO This id is not the one for a particular flavor
     // but the one from the source, which in this case is a node
     // This is tricky since we really have a lot of id's for each node
-    // we will return  NULL and deal with trackin in our own hook.
+    // we will return  NULL and deal with tracking in our own hook.
     // @see search_api.module \search_api_node_access_records_alter
 
     return NULL;

--- a/src/Tools/SimpleXMLtoArray.php
+++ b/src/Tools/SimpleXMLtoArray.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 7/21/20
+ * Time: 12:01 PM
+ */
+
+namespace Drupal\strawberryfield\Tools;
+
+use \SimpleXMLElement;
+
+
+class SimpleXMLtoArray {
+
+  private $options = [
+    'namespaceSeparator' => ':',//you may want this to be something other than a colon
+    'attributePrefix' => '@',   //to distinguish between attributes and nodes with the same name
+    'alwaysArray' => [],   //array of xml tag names which should always become arrays
+    'autoArray' => FALSE,        //only create arrays for tags which appear more than once
+    'textContent' => '@value',       //key used for the text content of elements
+    'autoText' => FALSE,         //skip textContent key if node has no attributes or child nodes
+    'keySearch' => FALSE,       //optional search and replace on tag and attribute names
+    'keyReplace' => FALSE,
+    'keepPrefix' => TRUE // Don't user prefixes for elements. As simple as that.
+  ];
+
+  /**
+   * @var SimpleXMLElement
+   */
+  private $subject;
+
+  public function __construct(
+    SimpleXMLElement $element,
+    $options = []
+  ) {
+    $this->options = array_merge($options, $this->options);
+    $this->subject = $element;
+
+  }
+
+  public function xmlToArray(SimpleXMLElement $element = null) {
+
+    if ($element === null) {
+      $element = $this->subject;
+    }
+
+    //$namespaces = $element->getDocNamespaces();
+    $namespaces =  $element->getNamespaces();
+    $namespaces = array_unique($namespaces);
+    if (!isset($namespaces[''] )) {
+      $namespaces['']  = null;
+    }
+
+
+    //get attributes from all namespaces
+    $attributesArray = [];
+    foreach ($namespaces as $prefix => $namespace) {
+      foreach ($element->attributes($namespace) as $attributeName => $attribute) {
+        //replace characters in attribute name
+        if ($this->options['keySearch']) $attributeName =
+          str_replace($this->options['keySearch'], $this->options['keyReplace'], $attributeName);
+        if ($this->options['keepPrefix']) {
+          $attributeKey = $this->options['attributePrefix']
+            . ($prefix ? $prefix . $this->options['namespaceSeparator'] : '')
+            . $attributeName;
+        } else {
+          // If we don't want prefixes. Because sometimes they repeat!
+          $attributeKey = $this->options['attributePrefix']
+            . $attributeName;
+        }
+        $attributesArray[$attributeKey] = (string)$attribute;
+      }
+    }
+
+    //get child nodes from all namespaces
+    $tagsArray = [];
+    foreach ($namespaces as $prefix => $namespace) {
+      foreach ($element->children($namespace) as $childXml) {
+        //recurse into child nodes
+        $childArray = $this->xmlToArray($childXml);
+        // We can not use each() anymore, deprecated since PHP 7.2
+        list($childTagName, $childProperties) = [ key($childArray), current($childArray) ];
+        next($childArray);
+        //replace characters in tag name
+        if ($this->options['keySearch']) $childTagName =
+          str_replace($this->options['keySearch'], $this->options['keyReplace'], $childTagName);
+        //add namespace prefix, if any
+        if (($this->options['keepPrefix']) && ($prefix)) {
+          $childTagName = $prefix . $this->options['namespaceSeparator'] . $childTagName;
+        }
+
+        if (!isset($tagsArray[$childTagName])) {
+          //only entry with this key
+          //test if tags of this type should always be arrays, no matter the element count
+          $tagsArray[$childTagName] =
+            in_array($childTagName, $this->options['alwaysArray']) || !$this->options['autoArray']
+              ? [$childProperties] : $childProperties;
+        } elseif (
+          is_array($tagsArray[$childTagName]) && array_keys($tagsArray[$childTagName])
+          === range(0, count($tagsArray[$childTagName]) - 1)
+        ) {
+          //key already exists and is integer indexed array
+          $tagsArray[$childTagName][] = $childProperties;
+        } else {
+          //key exists so convert to integer indexed array with previous value in position 0
+          $tagsArray[$childTagName] = [$tagsArray[$childTagName], $childProperties];
+        }
+      }
+    }
+
+    //get text content of node
+    $textContentArray = [];
+    $plainText = trim((string)$element);
+    if ($plainText !== '') $textContentArray[$this->options['textContent']] = $plainText;
+
+    //stick it all together
+    $propertiesArray = !$this->options['autoText'] || $attributesArray || $tagsArray || ($plainText === '')
+      ? array_merge($attributesArray, $tagsArray, $textContentArray) : $plainText;
+
+    //return node as array
+    return [
+      $element->getName() => $propertiesArray
+    ];
+  }
+
+
+}
+


### PR DESCRIPTION
This pull adds new XML to JSON processing strategy in addition to the JSON encoding decorator we had. Deals with Namespaces in correct way and also allows certain path based functions to be exclude from our calculations so we don't store of process hundreds or thousands of JMES-JSON paths in our vocabulary. 

- Also fixes issue with our ingest drush command `jsonapi-ingest` (needs a refactor for 1.0.0, want to move our of `curl` to the internal `httpclient`) not reading/uploading files with filenames containing spaces which leads to a 0 byte upload.
