### PR TITLE
ISSUE-109: Verbosity on demand

### DIFF
--- a/src/Commands/JsonApiDrushCommands.php
+++ b/src/Commands/JsonApiDrushCommands.php
@@ -429,7 +429,6 @@ JSON;
           )) {
           $field_name = $options['fieldname'];
         }
-
       }
 
     }

--- a/src/EventSubscriber/StrawberryfieldEventDeleteFileUsageDeleter.php
+++ b/src/EventSubscriber/StrawberryfieldEventDeleteFileUsageDeleter.php
@@ -8,6 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
 
 
 /**
@@ -49,24 +50,34 @@ class StrawberryfieldEventDeleteFileUsageDeleter extends StrawberryfieldEventDel
   protected $loggerFactory;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
    * StrawberryfieldEventInsertFileUsageUpdater constructor.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    * @param \Drupal\strawberryfield\StrawberryfieldFilePersisterService $strawberry_filepersister
+   * @param \Drupal\Core\Session\AccountInterface $account
    */
   public function __construct(
     TranslationInterface $string_translation,
     MessengerInterface $messenger,
     LoggerChannelFactoryInterface $logger_factory,
-    StrawberryfieldFilePersisterService $strawberry_filepersister
+    StrawberryfieldFilePersisterService $strawberry_filepersister,
+    AccountInterface $account
 
   ) {
     $this->stringTranslation = $string_translation;
     $this->messenger = $messenger;
     $this->loggerFactory = $logger_factory;
     $this->strawberryfilepersister = $strawberry_filepersister;
+    $this->account = $account;
   }
 
 
@@ -83,12 +94,25 @@ class StrawberryfieldEventDeleteFileUsageDeleter extends StrawberryfieldEventDel
     // First one: removed count, second one:orphaned ones cleaned.
 
     $processedfiles = $this->strawberryfilepersister->removeUsageFilesInJson($entity);
-
-    if ($processedfiles[0] > 0) {
-      $this->messenger->addStatus($this->stringTranslation->formatPlural($processedfiles[0], 'One file usage removed for this digital Object.', '@count files usage removed for this digital Object.'));
-    }
-    if ($processedfiles[1] > 0) {
-      $this->messenger->addStatus($this->stringTranslation->formatPlural($processedfiles[1], 'One file usage removed for a no longer existing digital Object.', '@count files usage removed for no longer existing digital Objects.'));
+    if ($this->account->hasPermission('display strawberry messages')) {
+      if ($processedfiles[0] > 0) {
+        $this->messenger->addStatus(
+          $this->stringTranslation->formatPlural(
+            $processedfiles[0],
+            'One file usage removed for this digital Object.',
+            '@count files usage removed for this digital Object.'
+          )
+        );
+      }
+      if ($processedfiles[1] > 0) {
+        $this->messenger->addStatus(
+          $this->stringTranslation->formatPlural(
+            $processedfiles[1],
+            'One file usage removed for a no longer existing digital Object.',
+            '@count files usage removed for no longer existing digital Objects.'
+          )
+        );
+      }
     }
     $current_class = get_called_class();
     $event->setProcessedBy($current_class, TRUE);

--- a/src/EventSubscriber/StrawberryfieldEventInsertFileUsageUpdater.php
+++ b/src/EventSubscriber/StrawberryfieldEventInsertFileUsageUpdater.php
@@ -8,6 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
 
 
 /**
@@ -48,6 +49,12 @@ class StrawberryfieldEventInsertFileUsageUpdater extends StrawberryfieldEventIns
    */
   protected $strawberryfilepersister;
 
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
 
   /**
    * StrawberryfieldEventInsertFileUsageUpdater constructor.
@@ -56,18 +63,22 @@ class StrawberryfieldEventInsertFileUsageUpdater extends StrawberryfieldEventIns
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    * @param \Drupal\strawberryfield\StrawberryfieldFilePersisterService $strawberry_filepersister
+   * @param \Drupal\Core\Session\AccountInterface $account
    */
   public function __construct(
     TranslationInterface $string_translation,
     MessengerInterface $messenger,
     LoggerChannelFactoryInterface $logger_factory,
-    StrawberryfieldFilePersisterService $strawberry_filepersister
+    StrawberryfieldFilePersisterService $strawberry_filepersister,
+    AccountInterface $account
+
 
   ) {
     $this->stringTranslation = $string_translation;
     $this->messenger = $messenger;
     $this->loggerFactory = $logger_factory;
     $this->strawberryfilepersister = $strawberry_filepersister;
+    $this->account = $account;
   }
 
 
@@ -88,8 +99,8 @@ class StrawberryfieldEventInsertFileUsageUpdater extends StrawberryfieldEventIns
       $field = $entity->get($field_name);
       $updatedfiles = $updatedfiles + $this->strawberryfilepersister->updateUsageFilesInJson($field);
     }
-
-    if ($updatedfiles > 0) {
+    // Only generate UI messages if the user has this permission.
+    if (($updatedfiles > 0) &&  ($this->account->hasPermission('display strawberry messages'))) {
       $this->messenger->addStatus($this->stringTranslation->formatPlural($updatedfiles, 'One file usage tracked for this digital Object.', '@count files usage tracked for this digital Object.'));
     }
     $current_class = get_called_class();

--- a/src/EventSubscriber/StrawberryfieldEventInsertSubscriberDepositDO.php
+++ b/src/EventSubscriber/StrawberryfieldEventInsertSubscriberDepositDO.php
@@ -10,6 +10,7 @@ use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
+use Drupal\Core\Session\AccountInterface;
 use Datetime;
 
 /**
@@ -58,6 +59,13 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
   protected $loggerFactory;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
    * StrawberryfieldEventInsertSubscriberDepositDO constructor.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
@@ -65,6 +73,8 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
    * @param \Symfony\Component\Serializer\SerializerInterface $serializer
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
+   * @param \Drupal\strawberryfield\StrawberryfieldFilePersisterService $strawberry_filepersister
+   * @param \Drupal\Core\Session\AccountInterface $account
    */
   public function __construct(
     TranslationInterface $string_translation,
@@ -72,7 +82,8 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
     SerializerInterface $serializer,
     ConfigFactoryInterface $config_factory,
     LoggerChannelFactoryInterface $logger_factory,
-    StrawberryfieldFilePersisterService $strawberry_filepersister
+    StrawberryfieldFilePersisterService $strawberry_filepersister,
+    AccountInterface $account
   ) {
     $this->stringTranslation = $string_translation;
     $this->messenger = $messenger;
@@ -82,6 +93,7 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
     )->get('object_file_scheme');
     $this->loggerFactory = $logger_factory;
     $this->strawberryfilepersister = $strawberry_filepersister;
+    $this->account = $account;
   }
 
   /**
@@ -160,7 +172,7 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
     }
     $event->setProcessedBy($current_class, $success);
     // Entity is "assigned by reference" so any change on the entity here will persist.
-    if ($success) {
+    if ($success && $this->account->hasPermission('display strawberry messages')) {
       $this->messenger->addStatus(
         t('Digital Object persisted to Filesystem.')
       );
@@ -169,10 +181,11 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
         ['Entity ID' => $entity->id(), 'Entity Title' => $entity->label()]
       );
     }
+    // Errors need to be shown always. We do not disable this
     if (!$success) {
       $this->messenger->addError(
         t(
-          'Digital Object Serialization failed? We could not persist to Filesystem. Please check your logs.'
+          'Digital Object Serialization failed? We could not persist to Filesystem. Please contact your site admin.'
         )
       );
       $this->loggerFactory->get('archipelago')->critical(

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
@@ -8,6 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Session\AccountInterface;
 
 
 /**
@@ -82,24 +83,34 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
   protected $loggerFactory;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
    * StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator constructor.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    * @param \Drupal\strawberryfield\StrawberryfieldFilePersisterService $strawberry_filepersister
+   * @param \Drupal\Core\Session\AccountInterface $account
    */
   public function __construct(
     TranslationInterface $string_translation,
     MessengerInterface $messenger,
     LoggerChannelFactoryInterface $logger_factory,
-    StrawberryfieldFilePersisterService $strawberry_filepersister
+    StrawberryfieldFilePersisterService $strawberry_filepersister,
+    AccountInterface $account
 
   ) {
     $this->stringTranslation = $string_translation;
     $this->messenger = $messenger;
     $this->loggerFactory = $logger_factory;
     $this->strawberryfilepersister = $strawberry_filepersister;
+    $this->account = $account;
   }
 
 

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberFilePersister.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberFilePersister.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\strawberryfield\EventSubscriber;
 
+use Drupal\Core\Session\AccountInterface;
 use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -56,24 +57,34 @@ class StrawberryfieldEventPresaveSubscriberFilePersister extends Strawberryfield
   protected $loggerFactory;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
    * StrawberryfieldEventPresaveSubscriberFilePersister constructor.
    *
    * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    * @param \Drupal\strawberryfield\StrawberryfieldFilePersisterService $strawberry_filepersister
+   * @param \Drupal\Core\Session\AccountInterface $account
    */
   public function __construct(
     TranslationInterface $string_translation,
     MessengerInterface $messenger,
     LoggerChannelFactoryInterface $logger_factory,
-    StrawberryfieldFilePersisterService $strawberry_filepersister
+    StrawberryfieldFilePersisterService $strawberry_filepersister,
+    AccountInterface $account
 
   ) {
     $this->stringTranslation = $string_translation;
     $this->messenger = $messenger;
     $this->loggerFactory = $logger_factory;
     $this->strawberryfilepersister = $strawberry_filepersister;
+    $this->account = $account;
   }
 
 
@@ -95,7 +106,7 @@ class StrawberryfieldEventPresaveSubscriberFilePersister extends Strawberryfield
       /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
       $newlysavedcount = $newlysavedcount + $this->strawberryfilepersister->persistFilesInJsonToDisks($field);
     }
-    if ($newlysavedcount > 0) {
+    if ($newlysavedcount > 0 && $this->account->hasPermission('display strawberry messages')) {
       $this->messenger->addStatus($this->stringTranslation->formatPlural($newlysavedcount, 'Very good. New file persisted to permanent Storage.', 'Great! @count new files persisted to permanent Storage.'));
     }
     $current_class = get_called_class();

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata.php
@@ -6,9 +6,9 @@ use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
-use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Component\Utility\Unicode;
+use Drupal\Core\Session\AccountInterface;
 
 
 /**
@@ -44,6 +44,12 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
    */
   protected $loggerFactory;
 
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
 
   /**
    * StrawberryfieldEventPresaveSubscriberFilePersister constructor.
@@ -55,12 +61,14 @@ class StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata extends Strawber
   public function __construct(
     TranslationInterface $string_translation,
     MessengerInterface $messenger,
-    LoggerChannelFactoryInterface $logger_factory
+    LoggerChannelFactoryInterface $logger_factory,
+    AccountInterface $account
 
   ) {
     $this->stringTranslation = $string_translation;
     $this->messenger = $messenger;
     $this->loggerFactory = $logger_factory;
+    $this->account = $account;
   }
 
 

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberVocabCreator.php
@@ -6,6 +6,7 @@ use Drupal\strawberryfield\Event\StrawberryfieldCrudEvent;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Session\AccountInterface;
 use CachingIterator;
 use ArrayIterator;
 
@@ -28,6 +29,13 @@ class StrawberryfieldEventPresaveSubscriberVocabCreator extends StrawberryfieldE
    */
   protected $messenger;
 
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
 
   /**
    * Constructs a new StrawberryfieldEventPresaveSubscriberVocabCreator.
@@ -36,13 +44,16 @@ class StrawberryfieldEventPresaveSubscriberVocabCreator extends StrawberryfieldE
    *   The string translation.
    * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger.
+   * @param \Drupal\Core\Session\AccountInterface $account
    */
   public function __construct(
     TranslationInterface $string_translation,
-    MessengerInterface $messenger
+    MessengerInterface $messenger,
+    AccountInterface $account
   ) {
     $this->stringTranslation = $string_translation;
     $this->messenger = $messenger;
+    $this->account = $account;
   }
 
 
@@ -120,7 +131,7 @@ class StrawberryfieldEventPresaveSubscriberVocabCreator extends StrawberryfieldE
         }
       }
     }
-    if ($newlycreatedcount > 0) {
+    if ($newlycreatedcount > 0 && $this->account->hasPermission('display strawberry messages')) {
       $this->messenger->addStatus(t('New Terms added to the vocabulary'));
     }
   }

--- a/strawberryfield.permissions.yml
+++ b/strawberryfield.permissions.yml
@@ -10,3 +10,6 @@
 'JSON Patch Strawberryfield':
   title: 'JSON Patch Archipelago Digital Objects'
   description: 'Allows JSON Patch actions to be executed against a "Strawberryfield" bearing Entity. Still on Patch time, individual permissions may apply and/or override this permission'
+'display strawberry messages':
+ title: 'Display Strawberryfield generetaded Event Messages during Digital Object operations'
+ description: 'Shows UI/UX messages like file persistence, Vocabulary generation, etc that happen during Event driven processing. This may be annoying for not admin users so this permission may only be given to Admin users if needed.'

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -19,41 +19,39 @@ services:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberVocabCreator
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger']
+    arguments: ['@string_translation', '@messenger', '@current_user']
   strawberryfield.presave_as_filestructure_subscriber:
       class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator
       tags:
         - {name: event_subscriber}
-      arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister']
+      arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
   strawberryfield.presavefilepersister_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberFilePersister
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister']
+    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
   strawberryfield.presavesetlabelfrommetadata_subscriber:
      class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberSetTitlefromMetadata
      tags:
        - {name: event_subscriber}
-     arguments: ['@string_translation', '@messenger','@logger.factory']
+     arguments: ['@string_translation', '@messenger','@logger.factory','@current_user']
   strawberryfield.insertdeposit_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventInsertSubscriberDepositDO
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger', '@serializer','@config.factory','@logger.factory','@strawberryfield.file_persister']
+    arguments: ['@string_translation', '@messenger', '@serializer','@config.factory','@logger.factory','@strawberryfield.file_persister','@current_user']
   strawberryfield.insertfileusage_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventInsertFileUsageUpdater
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister']
+    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
   strawberryfield.deletefileusage_subscriber:
     class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventDeleteFileUsageDeleter
     tags:
       - {name: event_subscriber}
-    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister']
+    arguments: ['@string_translation', '@messenger','@logger.factory','@strawberryfield.file_persister','@current_user']
   strawberryfield.paramconverter.entity:
     class: Drupal\strawberryfield\ParamConverter\UuidEntityConverter
     tags:
       - { name: paramconverter , priority: 10 }
-    arguments:
-      - '@entity_type.manager'
-      - '@entity.repository'
+    arguments: ['@entity_type.manager','@entity.repository']


### PR DESCRIPTION
See #109 

This adds 
- A new permission
![image](https://user-images.githubusercontent.com/6946023/98142502-dfe1a700-1e95-11eb-83ba-f0fff03aa2a2.png)
- A check of that permission every time we want to be verbose in SBF during a EventSubscriber

Reducing that way our dB/verbosity a lot and allowing non REPO aware avoid unnecessary burdens and deep knowledge of the ADO creation process.

How to test? Log in as the DEMO user and create a new ADO. Only Content creation message should appear, do the same as ADMIN, a bunch of tech-buzz-word stuff will pop up reassuring  your process was successful!

Also added. Now the JSON Patch Action that is used (with a form) by AMI has a simulation mode. I love simulation modes where nothing gets modified and we can watch how a JSON Patch affects metadata without harm.
