### PR TITLE
ISSUE-121: Make file deletion / removal of as:structures better

### DIFF
--- a/src/Controller/StrawberryfieldFlavorDatasourceSearchController.php
+++ b/src/Controller/StrawberryfieldFlavorDatasourceSearchController.php
@@ -216,13 +216,17 @@ class StrawberryfieldFlavorDatasourceSearchController extends ControllerBase {
             $result_snippets_base = [];
             if (isset($field[$allfields_translated_to_solr['ocr_text']]['snippets'])) {
               foreach ($field[$allfields_translated_to_solr['ocr_text']]['snippets'] as $snippet) {
+                // IABR uses 0 to N-1. We may want to reprocess this for other endpoints.
+                $page_number = strpos($snippet['pages'][0]['id'], $page_prefix) === 0 ? (int) substr(
+                  $snippet['pages'][0]['id'],
+                  $page_prefix_len
+                ) : (int) $snippet['pages'][0]['id'];
+                // Just some check in case something goes wrong and page number is 0 or negative?
+                $page_number = ($page_number > 0) ? (int) ($page_number - 1) : 0;
                 $result_snippets_base = [
                   'par' => [
                     [
-                      'page' => strpos($snippet['pages'][0]['id'], $page_prefix) === 0 ? substr(
-                        $snippet['pages'][0]['id'],
-                        $page_prefix_len
-                      ) : $snippet['pages'][0]['id'],
+                      'page' => $page_number,
                       'boxes' => [],
                     ]
                   ]
@@ -232,20 +236,19 @@ class StrawberryfieldFlavorDatasourceSearchController extends ControllerBase {
                   $region_text = str_replace(
                     ['<em>', '</em>'],
                     ['{{{', '}}}'],
-                    $snippet['regions'][$highlight[0]['parentRegionIdx']]["text"]
+                    $snippet['regions'][$highlight[0]['parentRegionIdx']]['text']
                   );
                   $result_snippets_base['par'][0]['boxes'][] = [
-                    "l" => $highlight[0]['ulx'],
-                    "t" => $highlight[0]['uly'],
-                    "r" => $highlight[0]['lrx'],
-                    "b" => $highlight[0]['lry'],
-                    "page" => $result_snippets_base['par'][0]['page']
+                    'l' => $highlight[0]['ulx'],
+                    't' => $highlight[0]['uly'],
+                    'r' => $highlight[0]['lrx'],
+                    'b' => $highlight[0]['lry'],
+                    'page' => $page_number
                   ];
                 }
               }
-              $result_snippets_base["text"] = $region_text;
+              $result_snippets_base['text'] = $region_text;
             }
-
 
             $result_snippets[] = $result_snippets_base;
           }

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -33,12 +33,16 @@ use Drupal\Core\Config\ImmutableConfig;
 use Drupal\strawberryfield\StrawberryfieldEventType;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use Drupal\Core\Url;
 
 
 /**
  * Provides a SBF File persisting class.
  */
 class StrawberryfieldFilePersisterService {
+
+  const FILE_IRI_PREFIX = 'urn:uuid:';
+  const AS_TYPE_PREFIX = 'as:';
 
   use StringTranslationTrait;
   use MessengerTrait;
@@ -369,6 +373,14 @@ class StrawberryfieldFilePersisterService {
     return trim($basename, ' -');
   }
 
+  public function calculateAsKeyFromFile(FileInterface $file) {
+    // Calculate the destination json key
+      $as_file_type = explode('/', $file->getMimeType());
+      $as_file_type = count($as_file_type) == 2 ? $as_file_type[0] : 'document';
+      $as_file_type = ($as_file_type != 'application') ? $as_file_type : 'document';
+      return $as_file_type;
+  }
+
   /**
    *  Generates the full AS metadata structure to keep track of SBF files.
    *
@@ -451,11 +463,8 @@ class StrawberryfieldFilePersisterService {
       }
 
       // Calculate the destination json key
-      $as_file_type = explode('/', $file->getMimeType());
-      $as_file_type = count($as_file_type) == 2 ? $as_file_type[0] : 'document';
-      $as_file_type = ($as_file_type != 'application') ? $as_file_type : 'document';
-
-      $files_bytype_many[$as_file_type]['urn:uuid:' . $file->uuid()] = $file;
+      $as_file_type = $this->calculateAsKeyFromFile($file);
+      $files_bytype_many[$as_file_type][self::FILE_IRI_PREFIX . $file->uuid()] = $file;
       // Simpler structure to iterate over
       $file_list[$as_file_type][] = $file->id();
     }
@@ -465,11 +474,11 @@ class StrawberryfieldFilePersisterService {
 
     $to_process = [];
     foreach ($file_list as $askey => $fileids) {
-      $fileinfo_bytype_many['as:' . $askey] = [];
-      if (isset($cleanjson['as:' . $askey])) {
+      $fileinfo_bytype_many[self::AS_TYPE_PREFIX . $askey] = [];
+      if (isset($cleanjson[self::AS_TYPE_PREFIX . $askey])) {
         // Gets us structures in place with checksum applied
-        $fileinfo_bytype_many['as:' . $askey] = $this->retrieve_filestructure_from_metadata(
-          $cleanjson['as:' . $askey],
+        $fileinfo_bytype_many[self::AS_TYPE_PREFIX . $askey] = $this->retrieve_filestructure_from_metadata(
+          $cleanjson[self::AS_TYPE_PREFIX . $askey],
           array_values($fileids),
           $file_source_key
         );
@@ -480,7 +489,7 @@ class StrawberryfieldFilePersisterService {
 
       $to_process[$askey] = array_diff_key(
         $files_bytype_many[$askey],
-        $fileinfo_bytype_many['as:' . $askey]
+        $fileinfo_bytype_many[self::AS_TYPE_PREFIX . $askey]
       );
     }
     // Final iteration
@@ -542,7 +551,7 @@ class StrawberryfieldFilePersisterService {
 
         //The node save hook will deal with moving data.
         // We don't need the key here but makes cleaning easier
-        $fileinfo_bytype_many['as:' . $askey]['urn:uuid:' . $uuid] = $fileinfo;
+        $fileinfo_bytype_many[self::AS_TYPE_PREFIX . $askey][self::FILE_IRI_PREFIX . $uuid] = $fileinfo;
         $newforsorting = TRUE;
         // Side effect of this is that if the same file id is referenced twice
         // by different fields, as:something will contain it once only.
@@ -559,10 +568,10 @@ class StrawberryfieldFilePersisterService {
       // with one exception. If the sequence matches the new order, which basically means
       // we are good.
 
-      uasort($fileinfo_bytype_many['as:' . $askey], array($this,'sortByFileName'));
+      uasort($fileinfo_bytype_many[self::AS_TYPE_PREFIX . $askey], array($this,'sortByFileName'));
       $max_sequence = 0;
       // Let's get the max sequence first.
-      $max_sequence = array_reduce($fileinfo_bytype_many['as:' . $askey], function($a, $b) {
+      $max_sequence = array_reduce($fileinfo_bytype_many[self::AS_TYPE_PREFIX . $askey], function($a, $b) {
        if (isset($b['sequence'])) {
          return max($a, (int) $b['sequence']);
           } else {
@@ -573,7 +582,7 @@ class StrawberryfieldFilePersisterService {
       // For each always wins over array_walk
       $i=0;
       $j=0;
-      foreach ($fileinfo_bytype_many['as:' . $askey] as &$item) {
+      foreach ($fileinfo_bytype_many[self::AS_TYPE_PREFIX . $askey] as &$item) {
         $i++;
        //Order is already given by uasort but not trustable in JSON
        //So we set sequence number but let's check first what we got
@@ -621,7 +630,7 @@ class StrawberryfieldFilePersisterService {
             $file_id_list
           )) && isset($info['checksum']) && (isset($info['dr:for']) && $info['dr:for'] == $file_source_key)) {
         // If present means it was persisted so 'url' and $file->getFileUri() will be the same.
-        $found['urn:uuid:' . $info['dr:uuid']] = $info;
+        $found[self::FILE_IRI_PREFIX . $info['dr:uuid']] = $info;
       }
     }
     return $found;
@@ -656,7 +665,7 @@ class StrawberryfieldFilePersisterService {
               // Allowing users to renamed/move files
               // Now only if it is temporary
               // Because all not temporaries are already persisted.
-              // This this clashes with the fact that the file structure
+              // This clashes with the fact that the file structure
               // Naming service will always try to name things in a certain
               // way. So either we allow both to act everytime or we
               // have a other 'move your files' service?
@@ -666,15 +675,15 @@ class StrawberryfieldFilePersisterService {
                 $uuid = $file->uuid();
                 $current_uri = $file->getFileUri();
                 // Get the info structure from flatten:
-                if (isset($flatvalues['urn:uuid:' . $uuid]) &&
-                  isset($flatvalues['urn:uuid:' . $uuid]['dr:fid']) &&
-                  ($flatvalues['urn:uuid:' . $uuid]['dr:fid'] = $fid) &&
-                    isset($flatvalues['urn:uuid:' . $uuid]['url']) &&
-                    !empty($flatvalues['urn:uuid:' . $uuid]['url'])) {
+                if (isset($flatvalues[self::FILE_IRI_PREFIX . $uuid]) &&
+                  isset($flatvalues[self::FILE_IRI_PREFIX . $uuid]['dr:fid']) &&
+                  ($flatvalues[self::FILE_IRI_PREFIX . $uuid]['dr:fid'] = $fid) &&
+                    isset($flatvalues[self::FILE_IRI_PREFIX . $uuid]['url']) &&
+                    !empty($flatvalues[self::FILE_IRI_PREFIX . $uuid]['url'])) {
                   // Weird egde case:
                   // What if same urn:uuid:uuid has multiple info structures?
                   // Flattener could end being double nested?
-                  $destination_uri = $flatvalues['urn:uuid:' . $uuid]['url'];
+                  $destination_uri = $flatvalues[self::FILE_IRI_PREFIX . $uuid]['url'];
                   // Only deal with expensive process if destination uri is
                   // different to the known one.
                   if ($destination_uri != $current_uri) {
@@ -735,6 +744,57 @@ class StrawberryfieldFilePersisterService {
     return $persisted;
   }
 
+
+  /**
+   * Removes a list of Files from the as:structure and decreases its Usage count.
+   *
+   * @param array $file_id_list
+   * @param array $originaljson
+   *
+   * @param int $nodeid
+   *
+   * @return array
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function removefromAsFileStructure(
+    array $file_id_list = [],
+    array $originaljson,
+    int $nodeid
+  ) {
+
+    /** @var \Drupal\file\FileInterface[] $files */
+    try {
+      $files = $this->entityTypeManager->getStorage('file')->loadMultiple(
+        $file_id_list
+      );
+    } catch (InvalidPluginDefinitionException $e) {
+      $this->messenger()->addError(
+        $this->t('Sorry, we had real issues loading your files during cleanup/removal. Invalid Plugin File Definition.')
+      );
+      return $originaljson;
+    } catch (PluginNotFoundException $e) {
+      $this->messenger()->addError(
+        $this->t('Sorry, we had real issues loading your files during cleanup/removal. File Plugin not Found')
+      );
+      return $originaljson;
+    }
+    // Iterate and classify by as: type
+    foreach ($files as $file) {
+      $as_file_type = $this->calculateAsKeyFromFile($file);
+      $uuid = $file->uuid();
+      if (isset($originaljson[self::AS_TYPE_PREFIX.$as_file_type][self::FILE_IRI_PREFIX.$uuid])) {
+        // Double check, may be silly but hey!
+        if (isset($originaljson[self::AS_TYPE_PREFIX.$as_file_type][self::FILE_IRI_PREFIX.$uuid]['dr:fid']) &&
+          $originaljson[self::AS_TYPE_PREFIX.$as_file_type][self::FILE_IRI_PREFIX.$uuid]['dr:fid'] == $file->id()) {
+          unset($originaljson[self::AS_TYPE_PREFIX.$as_file_type][self::FILE_IRI_PREFIX.$uuid]);
+          $this->remove_file_usage($file, $nodeid, 'node', 1);
+        }
+      }
+    }
+    return $originaljson;
+  }
   /**
    * Deals with tracking file usage inside a strawberryfield.
    *
@@ -1023,8 +1083,6 @@ class StrawberryfieldFilePersisterService {
     // Reasons why we can not are:
     // - Wrong path settings.
     // - Disabled.
-    // Should we notify the user if processing is enabled and binaries can not
-    // be found? and or can not run?
 
     if (!$this->extractFileMetadata) {
       // early return if not allowed.
@@ -1038,6 +1096,7 @@ class StrawberryfieldFilePersisterService {
       'exif_exec_path'));
     $fido_exec_path = trim($this->config->get('fido_exec_path'));
     $identify_exec_path = trim($this->config->get('identify_exec_path'));
+    // @TODO NOT USED. SHOULD BE REMOVED IN RC2
     $pdf_info_exec_path = trim($this->config->get('pdfinfo_exec_path'));
 
     $uri = $file->getFileUri();
@@ -1054,15 +1113,16 @@ class StrawberryfieldFilePersisterService {
     )) {
       // Local stream.
       $cache_key = md5($uri);
+      $ext = pathinfo($uri, PATHINFO_EXTENSION);
       // Check first if the file is already around in temp?
       // @TODO can be sure its the same one? Ideas?
-      if (is_readable($this->fileSystem->realpath('temporary://sbr_' . $cache_key . '_' . basename($uri)))) {
-        $templocation = $this->fileSystem->realpath('temporary://sbr_' . $cache_key . '_' . basename($uri));
+      if (is_readable($this->fileSystem->realpath('temporary://sbr_' . $cache_key . '.' . $ext))) {
+        $templocation = $this->fileSystem->realpath('temporary://sbr_' . $cache_key . '.' . $ext);
       }
       else {
         $templocation = $this->fileSystem->copy(
           $uri,
-          'temporary://sbr_' . $cache_key . '_' . basename($uri),
+          'temporary://sbr_' . $cache_key . '.' . $ext,
           FileSystemInterface::EXISTS_REPLACE
         );
         $templocation = $this->fileSystem->realpath(
@@ -1078,7 +1138,7 @@ class StrawberryfieldFilePersisterService {
 
     if (!$templocation) {
       $this->loggerFactory->get('strawberryfield')->warning(
-        'Could not adquire a local accesible location for metadata extraction for file with URL @fileurl',
+        'Could not adquire a local accessible location for metadata extraction for file with URL @fileurl. Aborted processing. Please check you have space in your temporary storage location.',
         [
           '@fileurl' => $file->getFileUri(),
         ]
@@ -1096,9 +1156,9 @@ class StrawberryfieldFilePersisterService {
       // Silly really. This needs to be tighter but then unix allows any alias to exist.
       if (strlen($exif_exec_path) > 0) {
         $result_exif = exec(
-          $exif_exec_path . ' -json -q -a -gps:all -Common "-gps*" -xmp:all -XMP-tiff:Orientation -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . escapeshellarg(
+          $exif_exec_path . ' -json -q -a -gps:all -Common "-gps*" -xmp:all -XMP-tiff:Orientation -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . "'". escapeshellarg(
             $templocation
-          ),
+          ). "'",
           $output_exif,
           $status_exif
         );
@@ -1137,9 +1197,19 @@ class StrawberryfieldFilePersisterService {
           }
         }
       }
+      else {
+        $this->loggerFactory->get('strawberryfield')->warning(
+          '@fileurl was not processed using EXIF extraction because the path is not set. <a href="@url">Please configure it here</a>',
+          [
+            '@fileurl' => $file->getFileUri(),
+            '@url' => Url::fromRoute('strawberryfield.file_persister_settings_form')->toString()
+          ]
+        );
+      }
+
       if (strlen($fido_exec_path) > 0) {
         $result_fido = exec(
-          $fido_exec_path . ' ' . escapeshellarg($templocation),
+          $fido_exec_path . ' ' . "'". escapeshellarg($templocation). "'",
           $output_fido,
           $status_fido
         );
@@ -1168,16 +1238,23 @@ class StrawberryfieldFilePersisterService {
             $metadata['flv:pronom'] = $pronom;
           }
         }
+      } else {
+        $this->loggerFactory->get('strawberryfield')->warning(
+          '@fileurl was not processed using FIDO (Pronom) because the path is not set. <a href="@url">Please configure it here</a>',
+          [
+            '@fileurl' => $file->getFileUri(),
+            '@url' => Url::fromRoute('strawberryfield.file_persister_settings_form')->toString()
+          ]
+        );
       }
-
       // Only run identify on Images/Documents?
       // Do we need an exact list?
       if (strlen($identify_exec_path) > 0) {
         if (in_array($askey, ['document', 'image', 'video', 'audio'])) {
           $result_identify = exec(
-            $identify_exec_path . " -format 'format:%m|width:%w|height:%h|orientation:%[orientation]@' -quiet " . escapeshellarg(
+            $identify_exec_path . " -format 'format:%m|width:%w|height:%h|orientation:%[orientation]@' -quiet " . "'". escapeshellarg(
               $templocation
-            ),
+            ). "'",
             $output_identify,
             $status_identify
           );
@@ -1223,6 +1300,15 @@ class StrawberryfieldFilePersisterService {
             }
           }
         }
+      }
+      else {
+        $this->loggerFactory->get('strawberryfield')->warning(
+          '@fileurl was not processed using Identify (Media characterization) because the path is not set. <a href="@url">Please configure it here</a>',
+          [
+            '@fileurl' => $file->getFileUri(),
+            '@url' => Url::fromRoute('strawberryfield.file_persister_settings_form')->toString()
+          ]
+        );
       }
     }
     return $metadata;

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -1148,6 +1148,9 @@ class StrawberryfieldFilePersisterService {
 
 
     if ($templocation) {
+      $templocation_for_exec = escapeshellarg($templocation);
+      // In case i need to replace values/cleanup the name but we control the name
+      // So it should not be an issue?
       // @TODO MOVE CHECKSUM here
       $output_exif = '';
       $output_fido = '';
@@ -1156,13 +1159,10 @@ class StrawberryfieldFilePersisterService {
       // Silly really. This needs to be tighter but then unix allows any alias to exist.
       if (strlen($exif_exec_path) > 0) {
         $result_exif = exec(
-          $exif_exec_path . ' -json -q -a -gps:all -Common "-gps*" -xmp:all -XMP-tiff:Orientation -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . "'". escapeshellarg(
-            $templocation
-          ). "'",
+          $exif_exec_path . ' -json -q -a -gps:all -Common "-gps*" -xmp:all -XMP-tiff:Orientation -ImageWidth -ImageHeight -Canon -Nikon-AllDates -pdf:all -ee -MIMEType ' . $templocation_for_exec,
           $output_exif,
           $status_exif
         );
-
 
         // First EXIF
         if ($status_exif != 0) {
@@ -1209,7 +1209,7 @@ class StrawberryfieldFilePersisterService {
 
       if (strlen($fido_exec_path) > 0) {
         $result_fido = exec(
-          $fido_exec_path . ' ' . "'". escapeshellarg($templocation). "'",
+          $fido_exec_path . ' ' . $templocation_for_exec,
           $output_fido,
           $status_fido
         );
@@ -1252,9 +1252,7 @@ class StrawberryfieldFilePersisterService {
       if (strlen($identify_exec_path) > 0) {
         if (in_array($askey, ['document', 'image', 'video', 'audio'])) {
           $result_identify = exec(
-            $identify_exec_path . " -format 'format:%m|width:%w|height:%h|orientation:%[orientation]@' -quiet " . "'". escapeshellarg(
-              $templocation
-            ). "'",
+            $identify_exec_path . " -format 'format:%m|width:%w|height:%h|orientation:%[orientation]@' -quiet " . $templocation_for_exec,
             $output_identify,
             $status_identify
           );


### PR DESCRIPTION
See #121 
# What is new?

## On the StrawberryfieldFilePersisterService class
- Simple  public function `calculateAsKeyFromFile(FileInterface $file)` that uses the `mimetype` to get the `as:filetypes`, etc keys. Code was already there but since we needed to reuse it I made a method
-  Moved all mentions of 'as:' and 'urn:uuid' to CONSTANTS in the class. Cleaner, better.
-  New method that given a list of file ids removes any entry of those from the JSON inside the as:structure
public function removefromAsFileStructure(). I also, once removed decreases the Usage count since no other service has actually access to that info. And this is the right moment to do so. 
- Singe 1 count removal is applied using `$this->remove_file_usage($file, $nodeid, 'node', 1)` 
- Returns the original FULL JSON (not the previous one) with `as:filetype` entries removed.

PS: Since i was here added some Logging in case some of the basic identify, etc processors are empty and also double checked that in case an upload file has spaces we single quote them to avoid issues. This is related to #120

NOTE: @alliomeria @giancalro can you ingest a JP2 tomorrow and see if you get `flv:identif` data stored in your JSON? In one of my test machines identify could not and i hope its not because the shipped graphicsmagic lacks that decoder. If so I may want to compile Graphicsmagic again for the PHP 7.4 container

@patdunlavey. You will want to see this and ask/look since this service is quite heavy and important in the whole file parsing/cleaning/adding/keeping safe mechanic. And you will spend some time on this file in the future.

On the actual Event Subscriber (which uses the code explained before)

- We ask SBF for its original (previous saved data) and get the flattened values
- We ask for all the dr:fid values (means any file mentioned/referenced)
- During new file processing we keep a list of all File IDs added
- After that we compare old files with new files. Difference is Magically (hahaha) the ones that are not longer with us.

We call  `$this->strawberryfilepersister->removefromAsFileStructure(
                $to_be_removed_files, $fullvalues, $entity->id())` to remove those left over `as:filetype` from the JSON

Then instead of iterating and cleaning over the "newly processed" because guess what.. if you deleted all newly processed will have no iteration, we iterate over every possible key (only a few StrawberryfieldJsonHelper::AS_FILE_TYPE really) and check if there is previous data for that as:key, if there is new data for that same as:key. If new data is we use that as main and only complement with old left over data. Which one if we deleted that just now? Well, we can actually have URLS and EXTERNAL files not managed by us. But. That also needs to be mimic in the WEBFORM because that little rascal gets rid of those.

ALSO @alliomeria : only reason we have this processing on the webform is because of ESIE. We may totally want to disable that option and let this part deal with everything as originally planned. OR. We can make that processing simply a checkbox/option in the SBF harvester so the rest of the world does not need to suffer with extra ARRAY traversing.


How to test: 

- Create a new Object and add a few files. Save.
- Check if all is there and RAW metadata is OK and no warning in the logs

- Go back and remove all of a certain type of file (e.g documents): Save. 
- Check that both Files and as:entries are gone and also the corresponding e.g `as:document` is totally gone

- Go back and add more files: Save.
- Check if all is there and RAW metadata is OK and no warning in the logs

- Remove one of each type. Save
- Check if all is there and RAW metadata is OK and no warning in the logs

- Remove all Files. Save
- Check if NOTHING is left and rest of RAW metadata is OK and no warning in the logs

Now check in your admin/content/ for the deleted files and see if there are still Usages left

Usage is removed (-1) on each deletion
But also added +1 on each versioning (if all is good and I did not make any mistakes)

The idea is that NODE revision the contains a certain file adds usage
Every time a file is deleted we decrease USAGE and for extra security(nobody wants to loose a file) the Computed "drop_box" field we have keeps at ENTITY NODE level an extra connection which only gets removed if the WHOLE node and every revision are deleted.

