### PR TITLE
ISSUE-127: Adds a reverse Mime type guesser and the Hydroponics Background processor!

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -181,3 +181,18 @@ field.formatter.settings.strawberry_default_formatter:
     limit_access:
       type: string
       label: 'Access level the user needs on a bundle to be able to see it rendered, defaults to "edit"'
+
+# Multiple JSON type / View Mode Mappings
+strawberryfield.hydroponics_settings:
+  type: config_object
+  label: 'Queues enabled to be processed by the Hydroponics Service'
+  mapping:
+    active:
+      type: boolean
+      label: If Hydroponics Service is enabled or not
+    queues:
+      type: sequence
+      label: 'Queues marked as to be run by the Hydroponics Service'
+      sequence:
+        type: string
+        label: 'Queue Names'

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -3,3 +3,7 @@ services:
     class: Drupal\strawberryfield\Commands\JsonApiDrushCommands
     tags:
        - { name: drush.command }
+  hydroponics.commands:
+    class: Drupal\strawberryfield\Commands\HydroponicsDrushCommands
+    tags:
+      - { name: drush.command }

--- a/src/Commands/HydroponicsDrushCommands.php
+++ b/src/Commands/HydroponicsDrushCommands.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 6/2/20
+ * Time: 11:15 AM
+ */
+
+namespace Drupal\strawberryfield\Commands;
+
+use Drush\Commands\DrushCommands;
+use Drush\Exec\ExecTrait;
+use Drush\Runtime\Runtime;
+use React\EventLoop\Factory;
+
+
+/**
+ * A SBF Drush commandfile for ground-less Strawberry Growing.
+ *
+ * Forks and executes a reactPHP loop to handle queues in background
+ *
+ */
+class HydroponicsDrushCommands extends DrushCommands {
+
+  use ExecTrait;
+
+  /**
+   * Forks itself and starts a reactPHP loop to run Queues
+   *
+   * @throws \Exception if something goes wrong
+   *
+   * @command archipelago:hydroponics
+   * @aliases ap-hy
+   *
+   * @usage archipelago:hydroponics
+   */
+  public function hydroponics(
+  ) {
+    $loop = Factory::create();
+    $timer_ping = $loop->addPeriodicTimer(3.0, function () {
+      // store a heartbeat every 3 seconds.
+      $currenttime = \Drupal::time()->getCurrentTime();
+      \Drupal::state()->set('hydroponics.heartbeat', $currenttime);
+    });
+
+    // Get which queues we should run:
+    $active_queues = \Drupal::config('strawberryfield.hydroponics_settings')->get('queues');
+    foreach($active_queues as $queue) {
+      $done[$queue] = 0;
+      $loop->addTimer(0.001, function ($timer) use ($queue, &$done) {
+        error_log("Starting to process $queue");
+        \Drupal::getContainer()
+          ->get('strawberryfield.hydroponics')
+          ->processQueue($queue, 360);
+        error_log("Finished processing $queue");
+        $done[$queue] = 1;
+      });
+    }
+
+
+
+    $timer2 = $loop->addPeriodicTimer(0.1, function ($timer) use ($loop, $done, $timer_ping) {
+      if (!empty($done) && (array_sum($done)) == count($done)) {
+        error_log("All Done, clearing the timers");
+        $loop->cancelTimer($timer_ping);
+        $loop->cancelTimer($timer);
+        \Drupal::state()->set('hydroponics.queurunner_last_pid.heartbeat', 0);
+      }
+    });
+
+    $loop->run();
+    Runtime::setCompleted();
+    //We're now in the child process.
+  }
+}

--- a/src/Form/HydroponicsSettingsForm.php
+++ b/src/Form/HydroponicsSettingsForm.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Drupal\strawberryfield\Form;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Database\Database;
+use Drupal\Core\Extension\ModuleHandler;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\Messenger;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\Core\Queue\QueueWorkerManager;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\State\StateInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\queue_ui\Form\OverviewForm;
+use Drupal\queue_ui\QueueUIManager;
+use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
+use Drupal\Core\Ajax\InvokeCommand;
+use Drupal\Core\Ajax\MessageCommand;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * ConfigurationForm for Queue Worker Selection to be run by Hydroponics Service.
+ */
+class HydroponicsSettingsForm extends ConfigFormBase {
+
+
+  /**
+   * The queue factory.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queueFactory;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The Drupal state storage.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * The Drupal module handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandler
+   */
+  protected $moduleHandler;
+
+  /**
+   * @var \Drupal\Core\Queue\QueueWorkerManager
+   */
+  private $queueWorkerManager;
+
+  /**
+   * @var \Drupal\queue_ui\QueueUIManager
+   */
+  private $queueUIManager;
+
+
+  /**
+   * OverviewForm constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   * @param \Drupal\Core\Queue\QueueFactory $queue_factory
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   * @param \Drupal\Core\State\StateInterface $state
+   * @param \Drupal\Core\Extension\ModuleHandler $module_handler
+   * @param \Drupal\Core\Queue\QueueWorkerManager $queueWorkerManager
+   * @param \Drupal\queue_ui\QueueUIManager $queueUIManager
+   * @param \Drupal\Core\Messenger\Messenger $messenger
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, QueueFactory $queue_factory, AccountInterface $current_user, StateInterface $state, ModuleHandler $module_handler, QueueWorkerManager $queueWorkerManager, Messenger $messenger) {
+    parent::__construct($config_factory);
+    $this->queueFactory = $queue_factory;
+    $this->currentUser = $current_user;
+    $this->state = $state;
+    $this->moduleHandler = $module_handler;
+    $this->queueWorkerManager = $queueWorkerManager;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'strawberryfield.hydroponics_settings'
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'strawberryfield_hydroponics_settings_form';
+  }
+
+  /**
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('queue'),
+      $container->get('current_user'),
+      $container->get('state'),
+      $container->get('module_handler'),
+      $container->get('plugin.manager.queue_worker'),
+      $container->get('messenger')
+    );
+  }
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('strawberryfield.hydroponics_settings');
+
+    $active =  $config->get('active') ? $config->get('active') : FALSE;
+    $enabled_queues =  !empty($config->get('queues')) ? array_flip($config->get('queues')) : [];
+
+    $form['active'] =  [
+      '#title' => 'If Hydroponics Queue Background processing Service should run or not.',
+      '#type' => 'checkbox',
+      '#required' => FALSE,
+      '#default_value' => $active,
+    ];
+
+    $form['table-row'] = [
+      '#type' => 'table',
+      '#prefix' => '<div id="table-fieldset-wrapper">',
+      '#suffix' => '</div>',
+      '#header' => [
+        $this->t('Queue Name'),
+        $this->t('Items'),
+        $this->t('Run via Hydroponics Background Processor'),
+      ],
+      '#empty' => $this->t('Sorry, There are no items!'),
+    ];
+
+
+    $queues = $this->queueWorkerManager->getDefinitions();
+    foreach ($queues as $name => $queue_definition) {
+      /** @var QueueInterface $queue */
+      $queue = $this->queueFactory->get($name);
+
+      $form['table-row'][$name] = [
+        'title' => [
+          '#markup' => (string) $queue_definition['title'],
+        ],
+        'items' => [
+          '#markup' => $queue->numberOfItems(),
+        ],
+        'active' => [
+          '#type' => 'checkbox',
+          '#required' => FALSE,
+          '#default_value' => isset($enabled_queues[$name]) ? TRUE: FALSE
+        ]
+      ];
+
+    }
+
+      return parent::buildForm($form, $form_state);
+  }
+
+
+
+  /**
+   * @param array $form
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+
+    parent::validateForm(
+      $form,
+      $form_state
+    ); // TODO: Change the autogenerated stub
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $enabled = [];
+    $global_active = (bool) $form_state->getValue('active');
+    foreach($form_state->getValue('table-row') as $queuename => $queue) {
+      if ($queue['active'] == 1) {
+        $enabled[] = $queuename;
+      }
+    }
+
+    $this->config('strawberryfield.hydroponics_settings')
+      ->set('active', $global_active)
+      ->set('queues', $enabled)
+      ->save();
+    parent::submitForm($form, $form_state);
+  }
+}

--- a/src/ProxyClass/StrawberryfieldMimeService.php
+++ b/src/ProxyClass/StrawberryfieldMimeService.php
@@ -1,0 +1,96 @@
+<?php
+// @codingStandardsIgnoreFile
+
+/**
+ * This file was generated via php core/scripts/generate-proxy-class.php 'Drupal\strawberryfield\StrawberryfieldMimeService' "web/modules/contrib/strawberryfield/src".
+ */
+
+namespace Drupal\strawberryfield\ProxyClass {
+
+    /**
+     * Provides a proxy class for \Drupal\strawberryfield\StrawberryfieldMimeService.
+     *
+     * @see \Drupal\Component\ProxyBuilder
+     */
+    class StrawberryfieldMimeService implements \Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface
+    {
+
+        use \Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+        /**
+         * The id of the original proxied service.
+         *
+         * @var string
+         */
+        protected $drupalProxyOriginalServiceId;
+
+        /**
+         * The real proxied service, after it was lazy loaded.
+         *
+         * @var \Drupal\strawberryfield\StrawberryfieldMimeService
+         */
+        protected $service;
+
+        /**
+         * The service container.
+         *
+         * @var \Symfony\Component\DependencyInjection\ContainerInterface
+         */
+        protected $container;
+
+        /**
+         * Constructs a ProxyClass Drupal proxy object.
+         *
+         * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+         *   The container.
+         * @param string $drupal_proxy_original_service_id
+         *   The service ID of the original service.
+         */
+        public function __construct(\Symfony\Component\DependencyInjection\ContainerInterface $container, $drupal_proxy_original_service_id)
+        {
+            $this->container = $container;
+            $this->drupalProxyOriginalServiceId = $drupal_proxy_original_service_id;
+        }
+
+        /**
+         * Lazy loads the real service from the container.
+         *
+         * @return object
+         *   Returns the constructed real service.
+         */
+        protected function lazyLoadItself()
+        {
+            if (!isset($this->service)) {
+                $this->service = $this->container->get($this->drupalProxyOriginalServiceId);
+            }
+
+            return $this->service;
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function inverseGuess($mimetype)
+        {
+            return $this->lazyLoadItself()->inverseGuess($mimetype);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function guess($path)
+        {
+            return $this->lazyLoadItself()->guess($path);
+        }
+
+        /**
+         * {@inheritdoc}
+         */
+        public function setMapping(array $mapping = NULL)
+        {
+            return $this->lazyLoadItself()->setMapping($mapping);
+        }
+
+    }
+
+}

--- a/src/StrawberryfieldHydroponicsService.php
+++ b/src/StrawberryfieldHydroponicsService.php
@@ -85,20 +85,24 @@ class StrawberryfieldHydroponicsService {
     $this->queueFactory = $queue_factory;
   }
 
+
   /**
    * Processes cron queues.
+   *
+   * @param $name
+   * @param int $time
+   *
+   * @return int
+   * @throws \Drupal\Component\Plugin\Exception\PluginException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
    */
   public function processQueue($name, $time = 120) {
     // Grab the defined cron queues.
-    error_log($name);
     $info = $this->queueManager->getDefinition($name);
-    error_log(var_export($info, true));
     if ($info) {
         // Make sure every queue exists. There is no harm in trying to recreate
         // an existing queue.
-
         $this->queueFactory->get($name)->createQueue();
-
         $queue_worker = $this->queueManager->createInstance($name);
         $end = time() + $time;
         $queue = $this->queueFactory->get($name, TRUE);
@@ -125,7 +129,11 @@ class StrawberryfieldHydroponicsService {
             watchdog_exception('cron', $e);
           }
         }
-      }
+    return $queue->numberOfItems();
+    }
+  else {
+    return 0;
+  }
   }
 
 

--- a/src/StrawberryfieldHydroponicsService.php
+++ b/src/StrawberryfieldHydroponicsService.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 6/26/19
+ * Time: 6:56 PM
+ */
+
+namespace Drupal\strawberryfield;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityFieldManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueWorkerManagerInterface;
+use Drupal\Core\Queue\RequeueException;
+use Drupal\Core\Queue\SuspendQueueException;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\file\FileInterface;
+use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\search_api\Entity\Index;
+/**
+ * Provides a SBF utility class.
+ */
+class StrawberryfieldHydroponicsService {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+
+   */
+  protected $configFactory;
+
+  /**
+   * The Module Handler.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface;
+   */
+  protected $moduleHandler;
+
+  /**
+   * @var \Drupal\Core\Queue\QueueWorkerManagerInterface
+   */
+  private $queueManager;
+
+  /**
+   * The queue factory.
+   *
+   * @var \Drupal\Core\Queue\QueueFactory
+   */
+  protected $queueFactory;
+
+
+  /**
+   * StrawberryfieldHydroponicsService constructor.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   * @param \Drupal\Core\Queue\QueueWorkerManagerInterface $queue_manager
+   */
+  public function __construct(
+    EntityTypeManagerInterface $entity_type_manager,
+    ConfigFactoryInterface $config_factory,
+    ModuleHandlerInterface $module_handler,
+    QueueWorkerManagerInterface $queue_manager,
+    QueueFactory $queue_factory
+  ) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->configFactory = $config_factory;
+    $this->moduleHandler = $module_handler;
+    $this->queueManager = $queue_manager;
+    $this->queueFactory = $queue_factory;
+  }
+
+  /**
+   * Processes cron queues.
+   */
+  public function processQueue($name, $time = 120) {
+    // Grab the defined cron queues.
+    error_log($name);
+    $info = $this->queueManager->getDefinition($name);
+    error_log(var_export($info, true));
+    if ($info) {
+        // Make sure every queue exists. There is no harm in trying to recreate
+        // an existing queue.
+
+        $this->queueFactory->get($name)->createQueue();
+
+        $queue_worker = $this->queueManager->createInstance($name);
+        $end = time() + $time;
+        $queue = $this->queueFactory->get($name, TRUE);
+        $lease_time = $time;
+        while (time() < $end && ($item = $queue->claimItem($lease_time))) {
+          try {
+            error_log('--- processing one time for '.$name);
+            $queue_worker->processItem($item->data);
+            $queue->deleteItem($item);
+          }
+          catch (RequeueException $e) {
+            // The worker requested the task be immediately requeued.
+            $queue->releaseItem($item);
+          }
+          catch (SuspendQueueException $e) {
+            // If the worker indicates there is a problem with the whole queue,
+            $queue->releaseItem($item);
+            watchdog_exception('cron', $e);
+
+          }
+          catch (\Exception $e) {
+            // In case of any other kind of exception, log it and leave the item
+            // in the queue to be processed again later.
+            watchdog_exception('cron', $e);
+          }
+        }
+      }
+  }
+
+
+  public function run() {
+    $config = $this->configFactory->get('strawberryfield.hydroponics_settings');
+    if ($config->get('active')) {
+      global $base_url;
+      $site_path = \Drupal::service('site.path'); // e.g.: 'sites/default'
+      $site_path = explode('/', $site_path);
+      $site_name = $site_path[1];
+      $queuerunner_pid = (int) \Drupal::state()->get('hydroponics.queurunner_last_pid', 0);
+
+      $lastRunTime = intval(\Drupal::state()->get('hydroponics.heartbeat'));
+      error_log($lastRunTime);
+      $currentTime = intval(\Drupal::time()->getRequestTime());
+      error_log('Saved PID' . $queuerunner_pid);
+      error_log(var_export(posix_kill($queuerunner_pid, 0), TRUE));
+      $running_posix = posix_kill($queuerunner_pid, 0);
+      if (!$running_posix || !$queuerunner_pid) {
+        error_log('Hydroponics Service Not running, starting');
+        error_log('Current Time:'.$currentTime);
+        error_log('last time seen was:'.$lastRunTime);
+        error_log('Time passed:'.($currentTime -$lastRunTime));
+        $cmd = 'drush archipelago:hydroponics --uri=' . $base_url;
+        $pid = exec(
+          sprintf("nohup %s > /tmp/hydroponics.log 2>&1 & echo $!", $cmd)
+        );
+        \Drupal::state()->set('hydroponics.queurunner_last_pid', $pid);
+        error_log('New PID'. $pid);
+      } else {
+        error_log('is already running');
+        error_log('Hydroponics Service Running with:'. $queuerunner_pid);
+        error_log('Current Time:'.$currentTime);
+        error_log('last time seen was:'.$lastRunTime);
+        error_log('Time passed:'.($currentTime -$lastRunTime));
+      }
+    }
+    else {
+      return;
+    }
+  }
+
+
+
+}

--- a/src/StrawberryfieldMimeService.php
+++ b/src/StrawberryfieldMimeService.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: dpino
+ * Date: 6/26/19
+ * Time: 6:56 PM
+ */
+
+namespace Drupal\strawberryfield;
+
+use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesserInterface;
+use Drupal\Core\File\MimeType\ExtensionMimeTypeGuesser;
+
+/**
+ * Makes possible to guess the extension of a file using the MIME type.
+ */
+class StrawberryfieldMimeService extends ExtensionMimeTypeGuesser implements MimeTypeGuesserInterface {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function inverseGuess($mimetype) {
+    if ($this->mapping === NULL) {
+      $mapping = $this->defaultMapping;
+      // Allow modules to alter the default mapping.
+      $this->moduleHandler->alter('file_mimetype_mapping', $mapping);
+      $this->mapping = $mapping;
+    }
+    $extension = 'bin';
+    foreach($this->mapping['mimetypes'] as $machine_name => $storedmimetype) {
+      if ($storedmimetype == $mimetype) {
+        $flipped = array_flip(array_reverse($this->mapping['extensions']));
+        if (isset($flipped[$machine_name])) {
+          return $flipped[$machine_name];
+        }
+      }
+    }
+    return $extension;
+  }
+}

--- a/strawberryfield.links.menu.yml
+++ b/strawberryfield.links.menu.yml
@@ -27,3 +27,10 @@ strawberryfield.important_solr_settings_form:
   description: 'Configure which Solr field is used in ADO Type Mapping'
   parent: strawberryfield.group.admin
   weight: 99
+
+strawberryfield.hydroponics_settings_form:
+  title: 'Queue Manager for Hydroponics Service'
+  route_name: strawberryfield.hydroponics_settings_form
+  description: 'Configure which Queues will run as Background Services'
+  parent: strawberryfield.group.admin
+  weight: 101

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -416,3 +416,14 @@ function strawberryfield_search_api_solr_query_alter(\Solarium\Core\Query\QueryI
     }
   }
 }
+
+function strawberryfield_cron() {
+  // @TODO: Drush calls to CRON do not release the background process? Wait
+  // For ever for the exec() to return, even if calling with nohup.
+  // @Giancarlobi.. not sure why. So this will only run if normal CRON/web based
+  // Is invoked but never with `drush cron`
+  if (PHP_SAPI != 'cli') {
+    \Drupal::getContainer()->get('strawberryfield.hydroponics')->run();
+  }
+}
+

--- a/strawberryfield.routing.yml
+++ b/strawberryfield.routing.yml
@@ -28,6 +28,16 @@ strawberryfield.file_persister_settings_form:
   options:
     _admin_route: TRUE
 
+strawberryfield.hydroponics_settings_form:
+  path: '/admin/config/archipelago/hydroponics'
+  defaults:
+    _form: '\Drupal\strawberryfield\Form\HydroponicsSettingsForm'
+    _title: 'Background Queue Processing Manager'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE
+
 strawberryfield.multiple_patch_confirm:
   path: '/admin/config/archipelago/actions/jsonpatch'
   defaults:

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -61,3 +61,6 @@ services:
     tags:
       - { name: mime_type_guesser }
     lazy: true
+  strawberryfield.hydroponics:
+    class: Drupal\strawberryfield\StrawberryfieldHydroponicsService
+    arguments: ['@entity_type.manager', '@config.factory', '@module_handler', '@plugin.manager.queue_worker', '@queue']

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -55,3 +55,9 @@ services:
     tags:
       - { name: paramconverter , priority: 10 }
     arguments: ['@entity_type.manager','@entity.repository']
+  strawberryfield.mime_type.guesser.mime:
+    class: Drupal\strawberryfield\StrawberryfieldMimeService
+    arguments: [ '@module_handler' ]
+    tags:
+      - { name: mime_type_guesser }
+    lazy: true


### PR DESCRIPTION
See #127

First one: This method is not provided by Drupal. There are a few modules that do this, but then they do not use the already existing alters. So better this way. This is the way 👶 

Second One: reactPHP and Drush working together to grow Strawberryfields without ground/dirt. Hydroponics Service/Background processor and settings/configs. A dream come true. Still, EXPERIMENTAL as hell. But its working well.

## What it does?
- It provides a Simple Form where Queues can be set as being managed by Hydroponics processor and a general /active/inactive key

- Adds a Cron hook (for now) that will check if there is a process, if the process is running and if not will exec via `nohup` a drush script and direct logs to /tmp/hydroponics.log. This may need to be better. We can, in theory send logs out to Docker logs, or somewhere else. But they need to go somewhere or `nohup` will still send output and we want to know what is going on! 

- A Hydroponics  service. Deals with checking if its running. And executing a Queue.

- The Hydroponics Drush script is a simple react loop that will gather all active queues and will run through them with a default lease of 60 seconds per queue. Also has a heartbeat (which we will use to kill a stuck process?) and once all queues are done/time is out (720 seconds) then the periodic timers will be suspended and we are done. Timing? We may want to make this longer? A setup config option? we can also measure CPU usage and Memory and decide to keep it running longer, days even.

How do we now its finished? BECAUSE my computer fans stopped working! but also because we get in the logs 
`Finished processing strawberryrunners_process_background`.

What is missing? A Process Killer. Stuck for long time but still running? Quite simple since we have the last heartbeat. We may want to setting like your original one @giancarlobi . For now, we can always kill it manually but I will add for RC2 status/time running/etc in the config form for hydroponics.

How to test?

AMI or SBR. Add some processing, PDFs, etc. Go to http://localhost:8001/admin/config/archipelago/hydroponics (Queue Manager for Hydroponics) and make sure you have something like this (your number of queues and items may vary)
![image](https://user-images.githubusercontent.com/6946023/103425171-9e603600-4b7e-11eb-9223-239241b237ad.png)

Save. Done. Now you can wait and see your numbers go down after a few hours or you can go to http://localhost:8001/admin/config/system/cron and run it. It won't execute if its running and if its running and still has time (720 seconds) I will keep processing queue items.

