### PR TITLE
ISSUE-136: Big bad BUG on as:filetype

### DIFF
--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -30,7 +30,10 @@ class StrawberryfieldJsonHelper {
     'as:video',
     'as:audio',
     'as:application',
-    'as:text'
+    'as:text',
+    'as:model',
+    'as:multipart',
+    'as:message',
   ];
 
   /**
@@ -73,11 +76,11 @@ class StrawberryfieldJsonHelper {
    */
   const URI_REGEXP =  '/
     # URI scheme RFC 3986 (http://tools.ietf.org/html/rfc3986)
-    
+
     (?(DEFINE)
-    
+
       # ABNF notation of RFC 2234 (http://tools.ietf.org/html/rfc2234#section-6.1)
-    
+
       (?<ALPHA>     [\x41-\x5A\x61-\x7A] )    # Latin character (A-Z, a-z)
       (?<CR>        \x0D )                    # Carriage return (\r)
       (?<DIGIT>     [\x30-\x39] )             # Decimal number (0-9)
@@ -85,38 +88,38 @@ class StrawberryfieldJsonHelper {
       (?<HEXDIG>    (?&DIGIT) | [\x41-\x46] ) # Hexadecimal number (0-9, A-F)
       (?<LF>        \x0A )                    # Line feed (\n)
       (?<SP>        \x20 )                    # Space
-    
+
       # RFC 3986 body
-    
+
       (?<uri>    (?&scheme) \: (?&hier_part) (?: \? (?&query) )? (?: \# (?&fragment) )? )
-    
+
       (?<hier_part>    \/\/ (?&authority) (?&path_abempty)
                      | (?&path_absolute)
                      | (?&path_rootless)
                      | (?&path_empty) )
-    
+
       (?<uri_reference>    (?&uri) | (?&relative_ref) )
-    
+
       (?<absolute_uri>    (?&scheme) \: (?&hier_part) (?: \? (?&query) )? )
-    
+
       (?<relative_ref>    (?&relative_part) (?: \? (?&query) )? (?: \# (?&fragment) )? )
-    
+
       (?<relative_part>     \/\/ (?&authority) (?&path_abempty)
                           | (?&path_absolute)
                           | (?&path_noscheme)
                           | (?&path_empty) )
-    
+
       (?<scheme>    (?&ALPHA) (?: (?&ALPHA) | (?&DIGIT) | \+ | \- | \. )* )
-    
+
       (?<authority>    (?: (?&userinfo) \@ )? (?&host) (?: \: (?&port) )? )
       (?<userinfo>     (?: (?&unreserved) | (?&pct_encoded) | (?&sub_delims) | \: )* )
       (?<host>         (?&ip_literal) | (?&ipv4_address) | (?&reg_name) )
       (?<port>         (?&DIGIT)* )
-    
+
       (?<ip_literal>    \[ (?: (?&ipv6_address) | (?&ipv_future) ) \] )
-    
+
       (?<ipv_future>    \x76 (?&HEXDIG)+ \. (?: (?&unreserved) | (?&sub_delims) | \: )+ )
-    
+
       (?<ipv6_address>                                              (?: (?&h16) \: ){6} (?&ls32)
                         |                                      \:\: (?: (?&h16) \: ){5} (?&ls32)
                         |                           (?&h16)?   \:\: (?: (?&h16) \: ){4} (?&ls32)
@@ -126,49 +129,49 @@ class StrawberryfieldJsonHelper {
                         | (?: (?: (?&h16) \: ){0,4} (?&h16) )? \:\:                     (?&ls32)
                         | (?: (?: (?&h16) \: ){0,5} (?&h16) )? \:\:                     (?&h16)
                         | (?: (?: (?&h16) \: ){0,6} (?&h16) )? \:\: )
-    
+
       (?<h16>             (?&HEXDIG){1,4} )
       (?<ls32>            (?: (?&h16) \: (?&h16) ) | (?&ipv4_address) )
       (?<ipv4_address>    (?&dec_octet) \. (?&dec_octet) \. (?&dec_octet) \. (?&dec_octet) )
-    
+
       (?<dec_octet>    (?&DIGIT)
                      | [\x31-\x39] (?&DIGIT)
                      | \x31 (?&DIGIT){2}
                      | \x32 [\x30-\x34] (?&DIGIT)
                      | \x32\x35 [\x30-\x35] )
-    
+
       (?<reg_name>     (?: (?&unreserved) | (?&pct_encoded) | (?&sub_delims) )* )
-    
+
       (?<path>    (?&path_abempty)
                 | (?&path_absolute)
                 | (?&path_noscheme)
                 | (?&path_rootless)
                 | (?&path_empty) )
-    
+
       (?<path_abempty>     (?: \/ (?&segment) )* )
       (?<path_absolute>    \/ (?: (?&segment_nz) (?: \/ (?&segment) )* )? )
       (?<path_noscheme>    (?&segment_nz_nc) (?: \/ (?&segment) )* )
       (?<path_rootless>    (?&segment_nz) (?: \/ (?&segment) )* )
       (?<path_empty>       (?&pchar){0} ) # For explicity only
-    
+
       (?<segment>       (?&pchar)* )
       (?<segment_nz>    (?&pchar)+ )
       (?<segment_nz_nc> (?: (?&unreserved) | (?&pct_encoded) | (?&sub_delims) | \@ )+ )
-    
+
       (?<pchar>    (?&unreserved) | (?&pct_encoded) | (?&sub_delims) | \: | \@ )
-    
+
       (?<query>    (?: (?&pchar) | \/ | \? )* )
-    
+
       (?<fragment>    (?: (?&pchar) | \/ | \? )* )
-    
+
       (?<pct_encoded>    \% (?&HEXDIG) (?&HEXDIG) )
-    
+
       (?<unreserved>    (?&ALPHA) | (?&DIGIT) | \- | \. | \_ | \~ )
       (?<reserved>      (?&gen_delims) | (?&sub_delims) )
       (?<gen_delims>    \: | \/ | \? | \# | \[ | \] | \@ )
       (?<sub_delims>    \! | \$ | \& | \' | \( | \)
                       | \* | \+ | \, | \; | \= )
-    
+
     )
     ^(?&uri)$
     /x';
@@ -461,12 +464,12 @@ class StrawberryfieldJsonHelper {
       }
     );
   }
-  
+
   /** Test if an input is a valid JSON string.
-   * 
+   *
    * @param $input
    *
-   * @return boolean 
+   * @return boolean
    */
   public static function isJsonString($input) {
     return is_string($input) && is_array(json_decode($input, true)) && (json_last_error() == JSON_ERROR_NONE);
@@ -503,5 +506,5 @@ class StrawberryfieldJsonHelper {
     }
   }
 
-  
+
 }


### PR DESCRIPTION
See #136

Using constansts to iterate over filetype is "better" and "cleaner" did he say.
Because as:model was missing once we removed the webform processing 3D Models stopped being classified. This is on me. ONLY ME!!! @alliomeria need to update hashes all around.

@alliomeria @giancarlobi 