### PR TITLE
ISSUE-143: Allow additional Drupal Entities to be extracted by StrawberryEntitiesViaJmesPathFromJson key name provider

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -61,10 +61,13 @@ strawberryfield.strawberry_keynameprovider.entityjmespath:
   mapping:
     source_key:
       type: string
-      label: 'A Comma separated string containing one or more JMESPaths pointing to JSON key with NODE ids.'
+      label: 'A Comma separated string containing one or more JMESPaths pointing to JSON keys containing Entity IDs or UUIDs. All need to share the same Entity Type.'
     exposed_key:
       type: string
       label: 'The field property we expose for the Strawberryfield'
+    entity_type:
+      type: string
+      label: 'The entity type that will be used to load the IDs present in the JSON Keys.'
 
 strawberryfield.storage_settings:
   type: config_object

--- a/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
@@ -43,6 +43,7 @@ class StrawberryEntitiesViaJmesPathFromJson extends StrawberryValuesViaJmesPathF
     }
     return $values;
   }
+
   /**
    * @param null $langcode
    *
@@ -97,7 +98,7 @@ class StrawberryEntitiesViaJmesPathFromJson extends StrawberryValuesViaJmesPathF
           $thing = $this->typedDataManager->create($target_id_definition);
           // No parent, so don't notify
           $thing->setValue($reference, FALSE);
-          // @TODO we may want to validate the existance of the reference here
+          // @TODO we may want to validate the existence of the reference here
           // To avoid issues of "not found" references if they get deleted
           // During Search Indexing.
           if ($thing->getTarget() instanceof ComplexDataInterface) {

--- a/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
@@ -57,10 +57,12 @@ class StrawberryEntitiesViaJmesPathFromJson extends StrawberryValuesViaJmesPathF
       $node_entities = [];
       /* @var $item StrawberryFieldItem */
       $definition = $this->getDataDefinition();
+
       // This key is passed by the property definition in the field class
       // jsonkey in this context is a string containing one or more
       // jmespath's separated by comma.
       $jmespaths = $definition['settings']['jsonkey'];
+      $entity_type = $definition['settings']['entitytype'] ?? 'node';
       $jmespath_array = array_map('trim', explode(',', $jmespaths));
       $jmespath_result = [];
       foreach ($jmespath_array as $jmespath) {
@@ -79,7 +81,6 @@ class StrawberryEntitiesViaJmesPathFromJson extends StrawberryValuesViaJmesPathF
       $this->processed = array_values($node_entities);
       $delta = 0;
       foreach ($this->processed as $reference) {
-
        // No way we can use  $this->createItem($delta, $reference); here
        // Because our public facing datatype is not what it seems
        // We can not use DataReferenceDefinitions here, we need actually EntityAdapter!
@@ -92,10 +93,13 @@ class StrawberryEntitiesViaJmesPathFromJson extends StrawberryValuesViaJmesPathF
         // Hackish! But genius?
         if (is_scalar($reference)) {
           $target_id_definition = DataReferenceDefinition::create('entity')
-            ->setTargetDefinition(EntityDataDefinition::create('node'));
+            ->setTargetDefinition(EntityDataDefinition::create($entity_type));
           $thing = $this->typedDataManager->create($target_id_definition);
           // No parent, so don't notify
           $thing->setValue($reference, FALSE);
+          // @TODO we may want to validate the existance of the reference here
+          // To avoid issues of "not found" references if they get deleted
+          // During Search Indexing.
           if ($thing->getTarget() instanceof ComplexDataInterface) {
             $delta++;
             $this->list[$delta] = $thing->getTarget();

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -139,6 +139,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
            }
            //@TODO HOW MANY KEYS? we should be able to set this per instance.
            $keynamelist[$processor_class] = array_merge($plugin_instance->provideKeyNames($entity_id), $keynamelist[$processor_class]);
+
            // Store the configuration options for use later.
            if(!empty($configuration_options['exposed_key'])) {
              $plugin_config_entity_configs[$processor_class][$configuration_options['exposed_key']] = $configuration_options;
@@ -161,6 +162,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
              // (assume 'node' if for some reason it is not provided).
              $referenced_entity_type = !empty($plugin_config_entity_configs[$processor_class][$property]['entity_type']) ?
                $plugin_config_entity_configs[$processor_class][$property]['entity_type'] : 'node';
+
              // Added a Setting 'entitytype' for field properties implementing
              // \Drupal\strawberryfield\Plugin\DataType\StrawberryEntitiesViaJmesPathFromJson
              // To allow that class to do its internal reference loading based on the given

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -109,6 +109,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
        ->setReadOnly(TRUE);
 
      $keynamelist = [];
+     $plugin_config_entity_configs = [];
      $item_types = [];
 
      // Fixes Search paging. Properties get lost because something in D8 fails
@@ -138,6 +139,10 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
            }
            //@TODO HOW MANY KEYS? we should be able to set this per instance.
            $keynamelist[$processor_class] = array_merge($plugin_instance->provideKeyNames($entity_id), $keynamelist[$processor_class]);
+           // Store the configuration options for use later.
+           if(!empty($configuration_options['exposed_key'])) {
+             $plugin_config_entity_configs[$processor_class][$configuration_options['exposed_key']] = $configuration_options;
+           }
          }
        }
      }

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -153,14 +153,6 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
              // Avoid internal reserved keys
              continue;
            }
-           // @TODO discuss with @giancarlobi
-           // This is a Hack and it does the job of allowing
-           // Search API's fieldHelper class to find the actual
-           // Elements. Since this is a property and we can not
-           // add Entity References Field Lists only base DataTypes
-           // We define this as a single Element (escaping the problem with the fact
-           // that each of our SBF in fact! can refer to MANY things. So delta
-           // Is included. But to allow functioning code to do the rest
            // We override the class ($processor_class) to actually use a ListInterface
            // data Type that pushes EntityAdapter objects.
            // Quite clever to be honest.
@@ -173,8 +165,10 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
              // \Drupal\strawberryfield\Plugin\DataType\StrawberryEntitiesViaJmesPathFromJson
              // To allow that class to do its internal reference loading based on the given
              // Entity Type at this level.
-             $properties[$property] = DataReferenceDefinition::create(
-               'entity'
+             // @TODO clean \Drupal\strawberryfield\Plugin\DataType\StrawberryEntitiesViaJmesPathFromJson
+             // To be less custom and simply use ::createItem().
+             $properties[$property] = ListDataDefinition::create(
+               'entity:'.$referenced_entity_type
              )
                ->setLabel('entity_'.$property)
                ->setComputed(TRUE)
@@ -182,9 +176,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
                ->setInternal(TRUE)
                ->setSetting('jsonkey', $keyname)
                ->setSetting('entitytype', $referenced_entity_type)
-               ->setReadOnly(TRUE)
-               ->setTargetDefinition(EntityDataDefinition::create($referenced_entity_type))
-               ->addConstraint('EntityType', $referenced_entity_type);
+               ->setReadOnly(TRUE);
            }
            else {
              $properties[$property] = ListDataDefinition::create(

--- a/src/Plugin/StrawberryfieldKeyNameProvider/EntityJmesPathNameProvider.php
+++ b/src/Plugin/StrawberryfieldKeyNameProvider/EntityJmesPathNameProvider.php
@@ -9,6 +9,7 @@
 namespace Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProvider;
 
 use Drupal\Core\Annotation\Translation;
+use Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 use Drupal\strawberryfield\Plugin\StrawberryfieldKeyNameProviderBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -43,7 +44,17 @@ class EntityJmesPathNameProvider extends JmesPathNameProvider {
       '#size' => 40,
       '#maxlength' => 255,
       '#default_value' => $this->getConfiguration()['source_key'],
-      '#description' => $this->t('JMespath(s) will be evaluated against your <em>Strawberry field</em> JSON to extract referenced Node entities.<br> e.g. ismemberof. Only Integer values are valid.'),
+      '#description' => $this->t('JMespath(s) will be evaluated against your <em>Strawberry field</em> JSON to extract referenced Drupal entities.<br> e.g. ismemberof. Only Integer values are valid.'),
+      '#required' => true,
+    ];
+    $supported_entities = str_replace('entity:', '', StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator::SUPPORTED_CORE_ENTITIES);
+    $element['entity_type'] = [
+      '#id' => 'entity_type',
+      '#type' => 'select',
+      '#title' => $this->t('Entity type.'),
+      '#options' => array_combine($supported_entities, $supported_entities),
+      '#default_value' => !empty($this->getConfiguration()['entity_type']) ? $this->getConfiguration()['entity_type'] : 'node',
+      '#description' => $this->t('The type of Drupal entity'),
       '#required' => true,
     ];
     // We need the parent form structure, if any, to make machine name work.

--- a/strawberryfield.install
+++ b/strawberryfield.install
@@ -14,12 +14,11 @@ use Drupal\field\Entity\FieldConfig;
  * Implements hook_install().
  */
 
-function strawberry_install() {
+function strawberryfield_install() {
   $vid = "strawberryfield_voc_id";
   $name = "Strawberryfield Metadata Keys";
   $vocabularies = Vocabulary::loadMultiple();
   if (!isset($vocabularies[$vid])) {
-
     // Create a vocabulary to hold strawberryfield json keys.
     $vocabulary = Vocabulary::create([
       'name' => $name,
@@ -39,12 +38,20 @@ function strawberry_install() {
 
     $field = FieldConfig::create(['field_storage' => $fieldstorage, 'bundle' => $vid]);
     $field->save();
-
   }
-  else {
-    // @TODO Vocabulary Already exist. Reuse as key provider.
-    $query = \Drupal::entityQuery('taxonomy_term');
-    $query->condition('vid', $vid);
-    $tids = $query->execute();
+}
+
+/**
+ * Adds entity_type default to entity reference strawberry keynameprovider.
+ */
+function strawberryfield_update_9101() {
+  $config_factory = \Drupal::configFactory();
+  // Find strawberry_keynameprovider configs that are using the entity jmespath
+  // provider and have no entity type set yet.
+  foreach ($config_factory->listAll('strawberryfield.strawberry_keynameprovider.*') as $keynameprovider_name) {
+    $keynameprovider = $config_factory->getEditable($keynameprovider_name);
+    if ($keynameprovider->get('pluginid') == 'entityjmespath' && $keynameprovider->get('pluginconfig.entity_type') == NULL) {
+      $keynameprovider->set('pluginconfig.entity_type', 'node')->save();
+    }
   }
 }

--- a/strawberryfield.install
+++ b/strawberryfield.install
@@ -48,7 +48,7 @@ function strawberryfield_update_9101() {
   $config_factory = \Drupal::configFactory();
   // Find strawberry_keynameprovider configs that are using the entity jmespath
   // provider and have no entity type set yet.
-  foreach ($config_factory->listAll('strawberryfield.strawberry_keynameprovider.*') as $keynameprovider_name) {
+  foreach ($config_factory->listAll('strawberryfield.strawberry_keynameprovider.') as $keynameprovider_name) {
     $keynameprovider = $config_factory->getEditable($keynameprovider_name);
     if ($keynameprovider->get('pluginid') == 'entityjmespath' && $keynameprovider->get('pluginconfig.entity_type') == NULL) {
       $keynameprovider->set('pluginconfig.entity_type', 'node')->save();


### PR DESCRIPTION
# What does this pull request

1.- It gives StrawberryEntitiesViaJmesPathFromJson Key Name provider a new setting so which entity type is being extracted can be set. All JMESPATHs selected in a single Key Name Provider configuration using this plugin need to be of the same type. 
2.- Changes the way we load Entity References as Exposed Properties of a StrawberryField Item, allowing many and still permitting Search API to index individual fields of the referenced entities of even the whole hierarchy (using the processor, this last one is a not proven statement but also not something I may want to promise for this ISSUE)
3.- Updates the schema for the plugin and adds Hook update so existing Key Name provider entities get "node" as default entity selected

# How to test?

Check this branch out. Remove your existing Search API fields using exposed properties (keys) using a keynote provider setup to use StrawberryEntitiesViaJmesPathFromJson, the ones we ship are `nid_ref` and nid_ref with prop path `field_descriptive_metadata:sbf_entity_reference_ismemberof:nid` and 
`sbf_entity_reference_title with prop` with  path `field_descriptive_metadata:sbf_entity_reference_ismemberof:title`

- This is needed since Solr will still thing these two paths provide single Values and not Lists of Data Types. (ss_* solr fields)
- Recreate them by adding them via the UI using the same machine names
- Save
- Reindex

Your Solr fields will change to sm_* for those machine names and will contain either a `[]` a  single value [`some value`] or an array of values. 

