### PR TITLE
ISSUE-151: Another different and better way of clearing/managing of `as:structures`

### DIFF
--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
@@ -10,6 +10,7 @@ use Drupal\strawberryfield\StrawberryfieldFilePersisterService;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
+use Drupal\Component\Uuid\Uuid;
 
 
 /**
@@ -120,21 +121,20 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
    *
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
    * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function onEntityPresave(StrawberryfieldCrudEvent $event) {
 
-    /* @var $entity \Drupal\Core\Entity\ContentEntityInterface */
+    /** @var $entity \Drupal\Core\Entity\ContentEntityInterface */
     $entity = $event->getEntity();
     $sbf_fields = $event->getFields();
 
     foreach ($sbf_fields as $field_name) {
-      /* @var $field \Drupal\Core\Field\FieldItemInterface */
+      /** @var $field \Drupal\Core\Field\FieldItemInterface */
       $field = $entity->get($field_name);
-      /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
-
+      /** @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
       if (!$field->isEmpty()) {
         $entity = $field->getEntity();
-        $entity_type_id = $entity->getEntityTypeId();
         /** @var $field \Drupal\Core\Field\FieldItemList */
         foreach ($field->getIterator() as $delta => $itemfield) {
           /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
@@ -145,34 +145,17 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
           if (!is_array($fullvalues)) {
             break;
           }
-          $original_fids = [];
-          // We will use the original data to compare if any files existing before were removed by the user
-          // Edge case. IF for some reason the user "escaped" our conditions and ended
-          // With an ADO with a SBF (not sure how) we want to check if the previous version
-          // REALLY has a SBF before trying to provide the flatten version
-          if (!$entity->isNew() && !empty($entity->original) && $entity->original->hasField($field_name)) {
-            try {
-              $original_field = $entity->original->get(
-                $field_name
-              );
-              if ($original_field !== NULL  && isset($original_field[$delta])) {
-                $original_fullvalues = $original_field[$delta]->provideFlatten();
-              $original_fids = isset($original_fullvalues['dr:fid']) ? $original_fullvalues['dr:fid'] : [];
-              $original_fids = is_array(
-                $original_fids
-              ) ? $original_fids : [$original_fids];
-              // To save some memory
-              unset($original_fullvalues);
-             } else {
-                $this->messenger->addWarning($this->t('Your previous revision did not have any JSON Metadata. This is strange. We worked around this but Please notify your site admin.'));
-              }
-            }
-            catch (\Exception $exception) {
-              $this->messenger->addError($this->t('We could not retrieve your original data to clean up any changes in attached files. Please contact the site admin.'));
-            }
-          }
+          $fullvalues_flat = $itemfield->provideFlatten();
+          $fids_from_as = isset($fullvalues_flat['dr:fid']) ? $fullvalues_flat['dr:fid'] : [];
+          $for_from_as = isset($fullvalues_flat['dr:for']) ? $fullvalues_flat['dr:for'] : [];
+          $fids_from_as = is_array(
+            $fids_from_as
+          ) ? $fids_from_as : [$fids_from_as];
+          $for_from_as = is_array(
+            $for_from_as
+          ) ? $for_from_as : [$for_from_as];
 
-          $fullvalues = $this->cleanUpEntityMappingStructure($fullvalues);
+          $fullvalues = $this->cleanUpEntityMappingStructure($fullvalues, $for_from_as);
           // 'ap:entitymapping' will always exists of ::cleanUpEntityMappingStructure
           $entity_mapping_structure = $fullvalues['ap:entitymapping'];
           $allprocessedAsValues = [];
@@ -183,7 +166,6 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
               // Here each $jsonkey_with_filenumids is a json key that holds file ids
               // Also $fullvalues[$jsonkeys_with_filenumids] will be there because
               // ::cleanUpEntityMappingStructure. Still, double check please?
-              $processedAsValuesForKey = [];
               $fullvalues[$jsonkey_with_filenumids] = isset($fullvalues[$jsonkey_with_filenumids]) ? $fullvalues[$jsonkey_with_filenumids] : [];
               // make even single files an array
               $fids = (is_array($fullvalues[$jsonkey_with_filenumids])) ? $fullvalues[$jsonkey_with_filenumids] : [$fullvalues[$jsonkey_with_filenumids]];
@@ -217,13 +199,13 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
 
             // Calculate the array_diff between OLD files and new ones
             $all_fids = array_unique($all_fids);
-            $original_fids = array_unique($original_fids);
-            $to_be_removed_files = array_diff($original_fids, $all_fids);
+            $fids_from_as = array_unique($fids_from_as);
+            $to_be_removed_files = array_diff($fids_from_as, $all_fids);
             if (is_array($to_be_removed_files) && count($to_be_removed_files) > 0) {
               // We remove from the fullvalues any file that was removed
               // This will also decrease the Usage Count for that file
               $fullvalues = $this->strawberryfilepersister->removefromAsFileStructure(
-                $to_be_removed_files, $fullvalues, $entity->id());
+                $to_be_removed_files, $fullvalues, $entity);
             }
 
             // WE should be able to load also UUIDs here.
@@ -249,7 +231,7 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
             }
             if (!$itemfield->setMainValueFromArray((array) $fullvalues)) {
               $this->messenger->addError($this->t('We could not persist file classification. Please contact the site admin.'));
-            };
+            }
           }
         }
       }
@@ -277,10 +259,20 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
    *     "ismemberof"
    *   }
    *
+   *  @param array $for_from_as
+   *    An array with all source keys (dr:from) fetched from the flat array
+   *    This may not exist of course.
+   *
    * @return array
    *   The cleaned/up $entityMapping
    */
-  private function cleanUpEntityMappingStructure(array $fullvalues) {
+  private function cleanUpEntityMappingStructure(array $fullvalues, array $for_from_as) {
+
+    // If not present of empty and we do have dr:for try to rebuild from that
+    // Its an edge cases but adds an extra level of dexterity/safety.
+    if (!isset($fullvalues['ap:entitymapping']['entity:file']) && !empty($for_from_as)) {
+      $fullvalues['ap:entitymapping']['entity:file'] = $for_from_as;
+    }
 
     if (isset($fullvalues['ap:entitymapping']) && is_array(
         $fullvalues['ap:entitymapping']
@@ -292,8 +284,7 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
       );
       // We can not have an array of arrays.
 
-      foreach ($entityMapping as $entity_type_key => &$jsonkeys_with_fileids) {
-        $jsonkeys_with_fileids_clean = [];
+      foreach ($entityMapping as $entity_type_key => $jsonkeys_with_fileids) {
         $jsonkeys_with_fileids_clean = array_filter(
           $jsonkeys_with_fileids,
           [$this,'isNotArray']
@@ -313,17 +304,11 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
         // nor if they are valid. IF we have 2000 entities
         // doing this here is an overkill. Just do when needed
         // Also: i really want to allow relationships to exist even before
-        // the referenced entites are present.
+        // the referenced entities are present.
         // We really care here only for the entity:file part
         // but will do our best to clean all.
       }
       $fullvalues['ap:entitymapping'] = $entityMapping;
-    }
-    else {
-      // If not here or not an array create the structure. We want it .
-      $fullvalues['ap:entitymapping'] = [
-        "entity:file" => [],
-      ];
     }
     return $fullvalues;
   }
@@ -336,7 +321,7 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
    * @return bool
    */
   private function isEntityId($val) {
-    return (is_int($val) && $val > 0) || \Drupal\Component\Uuid\Uuid::isValid(
+    return (is_int($val) && $val > 0) || Uuid::isValid(
         $val
       );
   }
@@ -354,7 +339,7 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
   /**
    * Array value callback. True if $key starts with Entity
    *
-   * @param mixed $val
+   * @param mixed $key
    *
    * @return bool
    */

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
@@ -125,19 +125,19 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
    */
   public function onEntityPresave(StrawberryfieldCrudEvent $event) {
 
-    /** @var $entity \Drupal\Core\Entity\ContentEntityInterface */
+    /** @var \Drupal\Core\Entity\ContentEntityInterface $entity*/
     $entity = $event->getEntity();
     $sbf_fields = $event->getFields();
 
     foreach ($sbf_fields as $field_name) {
-      /** @var $field \Drupal\Core\Field\FieldItemInterface */
+      /** @var \Drupal\Core\Field\FieldItemInterface $field*/
       $field = $entity->get($field_name);
       /** @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
       if (!$field->isEmpty()) {
         $entity = $field->getEntity();
         /** @var $field \Drupal\Core\Field\FieldItemList */
         foreach ($field->getIterator() as $delta => $itemfield) {
-          /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
+          /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $itemfield */
           $fullvalues = $itemfield->provideDecoded(TRUE);
 
           // SBF needs to have the entity mapping key

--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
@@ -261,14 +261,14 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
    *
    *  @param array $for_from_as
    *    An array with all source keys (dr:from) fetched from the flat array
-   *    This may not exist of course.
+   *    This may not exist of course and be an empty array.
    *
    * @return array
    *   The cleaned/up $entityMapping
    */
-  private function cleanUpEntityMappingStructure(array $fullvalues, array $for_from_as) {
+  private function cleanUpEntityMappingStructure(array $fullvalues, array $for_from_as = []) {
 
-    // If not present of empty and we do have dr:for try to rebuild from that
+    // If not present or empty and we do have dr:for try to rebuild from that
     // Its an edge cases but adds an extra level of dexterity/safety.
     if (!isset($fullvalues['ap:entitymapping']['entity:file']) && !empty($for_from_as)) {
       $fullvalues['ap:entitymapping']['entity:file'] = $for_from_as;

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -785,7 +785,7 @@ class StrawberryfieldFilePersisterService {
    * @throws \Drupal\Core\Entity\EntityStorageException
    */
   public function removefromAsFileStructure(
-    array $file_id_list = [],
+    array $file_id_list,
     array $originaljson,
     ContentEntityInterface $entity
   ) {
@@ -850,7 +850,7 @@ class StrawberryfieldFilePersisterService {
    * @return array
    */
   public function removefromAsFileStructureBrutForce(
-    array $file_id_list = [],
+    array $file_id_list,
     array $originaljson
   ) {
     // Iterate and over every as:file and compare against our known not existing

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -28,11 +28,7 @@ use Drupal\Core\Entity\ContentEntityInterface;
 use Drupal\strawberryfield\Event\StrawberryfieldJsonProcessEvent;
 use Drupal\Core\StreamWrapper\StreamWrapperInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
-use Drupal\strawberryfield\StrawberryfieldUtilityService;
-use Drupal\Core\Config\ImmutableConfig;
-use Drupal\strawberryfield\StrawberryfieldEventType;
-use Symfony\Component\Process\Exception\ProcessFailedException;
-use Symfony\Component\Process\Process;
+use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
 use Drupal\Core\Url;
 
 
@@ -781,7 +777,7 @@ class StrawberryfieldFilePersisterService {
    * @param array $file_id_list
    * @param array $originaljson
    *
-   * @param int $nodeid
+   * @param ContentEntityInterface $entity
    *
    * @return array
    * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
@@ -791,7 +787,7 @@ class StrawberryfieldFilePersisterService {
   public function removefromAsFileStructure(
     array $file_id_list = [],
     array $originaljson,
-    int $nodeid
+    ContentEntityInterface $entity
   ) {
 
     /** @var \Drupal\file\FileInterface[] $files */
@@ -809,13 +805,15 @@ class StrawberryfieldFilePersisterService {
     } catch (PluginNotFoundException $e) {
       $this->messenger()->addError(
         $this->t(
-          'Sorry, we had real issues loading your files during cleanup/removal. File Plugin not Found'
+          'Sorry, we had real issues loading your files during cleanup/removal. File Plugin not Found.'
         )
       );
       return $originaljson;
     }
+    $existing_ids = [];
     // Iterate and classify by as: type
     foreach ($files as $file) {
+      $existing_ids[] = $file->id();
       $as_file_type = $this->calculateAsKeyFromFile($file);
       $uuid = $file->uuid();
       if (isset($originaljson[self::AS_TYPE_PREFIX . $as_file_type][self::FILE_IRI_PREFIX . $uuid])) {
@@ -824,7 +822,46 @@ class StrawberryfieldFilePersisterService {
           $originaljson[self::AS_TYPE_PREFIX . $as_file_type][self::FILE_IRI_PREFIX . $uuid]['dr:fid'] == $file->id(
           )) {
           unset($originaljson[self::AS_TYPE_PREFIX . $as_file_type][self::FILE_IRI_PREFIX . $uuid]);
-          $this->remove_file_usage($file, $nodeid, 'node', 1);
+          // We can only remove usage for already saved content entities.
+          if (!$entity->isNew()) {
+            $this->remove_file_usage($file, $entity->id(), 'node', 1);
+          }
+        }
+      }
+    }
+
+    $not_existing = array_diff($file_id_list, $existing_ids);
+
+    // means we have left over files (coming from dr:fid that DO not longer
+    // exist inside Drupal as entities. Clean this up but in a costly way.
+    if (count($not_existing) > 0) {
+      $originaljson = $this->removefromAsFileStructureBrutForce($not_existing, $originaljson);
+    }
+
+    return $originaljson;
+  }
+
+  /**
+   * Removes a list of File IDs from the as:structure in a non optimal way.
+   *
+   * @param array $file_id_list
+   * @param array $originaljson
+   *
+   * @return array
+   */
+  public function removefromAsFileStructureBrutForce(
+    array $file_id_list = [],
+    array $originaljson
+  ) {
+    // Iterate and over every as:file and compare against our known not existing
+    // File entity IDs. If found remove.
+    foreach (StrawberryfieldJsonHelper::AS_FILE_TYPE as $file_key) {
+      if (isset($originaljson[$file_key]) &&
+        is_array($originaljson[$file_key])) {
+        foreach ($originaljson[$file_key] as $as_key => $as_entry) {
+          if (isset($as_entry['dr:fid']) && in_array($as_entry['dr:fid'], $file_id_list)) {
+            unset($originaljson[$file_key][$as_key]);
+          }
         }
       }
     }


### PR DESCRIPTION
#151

# What is new?

Instead of reaching out to the original entity SBF field values(if any) we use the flat version of the current SBF to fetch all `dr:fid` (referenced File IDs). We also fetch `dr:for` (source Keys for those field ids) to make sure we can, in case of "emergency" rebuild our file mapping from there and we do if that is the case (new)

We compare effectively File IDs inside `as:filetype` with File IDs provided in user contributed Keys found in the `ap:mapping` structure (in that order). If there are differences, those differences are File IDs that do not longer exist/were not provided by the user. We clean those up from the `as:filetype` and also check  (new) if there are Files that do not longer exists in Drupal (edge case but can happen if you copied a full JSON between repos) and clean them up Brut Force (basically old fashion foreach over an foreach checking who is referencing not existing Files).

Code is cleaner and should make sense but i need testing.

How to test:

- Ingest a new ADO without files. 
- Clone the previous files ADO and save without adding new files.  
- Edit and add files. Save.
- Edit and remove files add new Ones. Save
- Edit and Remove all files. Save

- Ingest a new ADO with Files.
- Clone and Change files during edit. Save
- Clone again and remove all files and Save.

- AMI ingest a few objects via CSV.

- Delete Objects and check if Usage Count decreases or not

For all of these, make sure no errors or warnings happen and in each step all files are inside the RAW JSON and the proper JSON as:filetype structures exists, no extra files, no missing files.

This is Core to archipelago an any error/not caught exception may be our/your files doom! So please test thoroughly!


@aksm @alliomeria @pcambra please give this a look and feel free to ask what the hell is happening. 
