### PR TITLE
ISSUE-156: Custom Edit Route when "use default" is disabled fails to check if form mode is enabled

### DIFF
--- a/src/Controller/CustomNodeEditController.php
+++ b/src/Controller/CustomNodeEditController.php
@@ -4,40 +4,33 @@ namespace Drupal\strawberryfield\Controller;
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
 use Drupal\node\NodeInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * Class CustomNodeEditController.
+ *
+ * @package strawberryfield
+ */
 class CustomNodeEditController extends ControllerBase {
 
   /**
    * The EntityDisplayRepository service.
    *
-   * @var \Drupal\core\Entity\EntityDisplayRepository $entityDisplayRepository
-   *
+   * @var \Drupal\core\Entity\EntityDisplayRepository
    */
   protected $entityDisplayRepository;
 
   /**
-   * Node form modes active for this current user
-   *
-   * @var array
-   *
-   */
-  protected $activeNodeFormModes;
-  
-  /**
-   * Constructs a new CustomNodeEditLocalTasks
+   * Constructs a new CustomNodeEditLocalTasks.
    *
    * @param \Drupal\Core\Entity\EntityDisplayRepositoryInterface $entity_display_repository
-   *
+   *   The EntityDisplayRepository service.
    */
   public function __construct(EntityDisplayRepositoryInterface $entity_display_repository) {
     $this->entityDisplayRepository = $entity_display_repository;
-    $this->activeNodeFormModes = $this->getActiveNodeFormModes();
   }
 
   /**
@@ -50,60 +43,50 @@ class CustomNodeEditController extends ControllerBase {
   }
 
   /**
-   * Returns form modes active for current user
+   * Returns form modes active for current user.
    *
-   * @return array 
-   *
+   * @return array
+   *   The list of active modes for the current user.
    */
-  public function getActiveNodeFormModes() {
-    $activeFormModes = [];
-    // "default" form mode is not returned from getFormModes(). Only named form modes.
-    $formModes = $this->entityDisplayRepository->getFormModes('node');
-    // Check which form modes user has access to
-    foreach ($formModes as $key => $value) {
-      if ($this->currentUser()->hasPermission("use {$value['id']} form mode")) {
-        $activeFormModes[$key] = $value;
-      }
-    }
-    
-    return $activeFormModes;
+  public function getActiveNodeFormModes(NodeInterface $node) {
+    $formModes = $this->entityDisplayRepository->getFormModeOptionsByBundle('node', $node->bundle());
+    return array_filter($formModes, function ($mode) {
+      return $this->currentUser()->hasPermission("use node.$mode form mode");
+    });
   }
 
-
   /**
-  * Grants access if user has access to a named form mode, but not default form mode.
-  *
-  * @param \Drupal\Core\Session\AccountInterface $account
-  *   Run access checks for this account.
-  *
-  * @return \Drupal\Core\Access\AccessResultInterface
-  *   The access result.
-  */
-  public function access(AccountInterface $account) {
-    $accessDefaultFormMode = $account->hasPermission('use default form mode');
-    $accessAnyFormMode = count($this->activeNodeFormModes) > 0;
-    
+   * Allows access if user has access to a form mode but not the default one.
+   *
+   * @return \Drupal\Core\Access\AccessResultInterface
+   *   The access result.
+   */
+  public function access(NodeInterface $node) {
+    $accessDefaultFormMode = $this->currentUser()->hasPermission('use node.default form mode');
+    $accessAnyFormMode = count($this->getActiveNodeFormModes($node)) > 0;
+
     return AccessResult::allowedIf(!$accessDefaultFormMode && $accessAnyFormMode);
   }
 
   /**
-   * Sends redirect response to first active form mode
+   * Sends redirect response to first active form mode.
    *
    * @param \Drupal\node\NodeInterface $node
-   *   Node parameter from route
+   *   Node parameter from route.
    *
-   * @return RedirectResponse
+   * @return \Symfony\Component\HttpFoundation\RedirectResponse
+   *   The form mode, 404 if not found.
    */
   public function redirectToForm(NodeInterface $node) {
-    // select one active form mode
-    $firstActiveFormMode = key($this->activeNodeFormModes);
+    $firstActiveFormMode = key($this->getActiveNodeFormModes($node));
     if ($firstActiveFormMode) {
-      return $this->redirect("entity.node.edit_form.{$firstActiveFormMode}", ["node" => $node->id()]);
-    } else {
-      // This shouldn't happen, because access check has already concluded there are active form modes.
-      // But just in case.
+      return $this->redirect("entity.node.edit_form.{$firstActiveFormMode}", ['node' => $node->id()]);
+    }
+    else {
+      // This shouldn't happen, because access check has already concluded there
+      // are active form modes. But just in case.
       throw new NotFoundHttpException();
     }
   }
-  
+
 }

--- a/strawberryfield.routing.yml
+++ b/strawberryfield.routing.yml
@@ -59,8 +59,6 @@ strawberryfield.custom_node_edit:
     parameters:
       node:
         type: entity:node
-      user:
-        type: entity:user
 
 # Direct access to Metadata display processed json using Metadata Expose Config Entity.
 strawberryfield.flavor_datasource_search:


### PR DESCRIPTION
This PR makes use of getFormModeOptionsByBundle among other cleanup tasks

Resolves #156 