### PR TITLE
ISSUE-156(second pass). Fix wrong array_filter

### DIFF
--- a/src/Controller/CustomNodeEditController.php
+++ b/src/Controller/CustomNodeEditController.php
@@ -51,8 +51,8 @@ class CustomNodeEditController extends ControllerBase {
   public function getActiveNodeFormModes(NodeInterface $node) {
     $formModes = $this->entityDisplayRepository->getFormModeOptionsByBundle('node', $node->bundle());
     return array_filter($formModes, function ($mode) {
-      return $this->currentUser()->hasPermission("use node.$mode form mode");
-    });
+      return $this->currentUser()->hasPermission("use node.{$mode} form mode");
+    }, ARRAY_FILTER_USE_KEY);
   }
 
   /**
@@ -62,9 +62,9 @@ class CustomNodeEditController extends ControllerBase {
    *   The access result.
    */
   public function access(NodeInterface $node) {
-    $accessDefaultFormMode = $this->currentUser()->hasPermission('use node.default form mode');
+    $accessDefaultFormMode = $this->currentUser()
+      ->hasPermission('use node.default form mode');
     $accessAnyFormMode = count($this->getActiveNodeFormModes($node)) > 0;
-
     return AccessResult::allowedIf(!$accessDefaultFormMode && $accessAnyFormMode);
   }
 


### PR DESCRIPTION
# What? A bug.

Well I should have double checked the code. My bad
PS: And now i know why i do not like array filters 😆  (I do like them.. but I fear them)

The array filter was using the value, the value is not a machine name so all permissions where failing. This adds ARRAY_FILTER_USE_KEY we have the actual form mode.

Also. My IDE's Drupal (verified I'm using the right now, I promise) DCS is putting long lines with method accessors in a second row. I hope this is the right thing... do I need to check again?