### PR TITLE
ISSUE-171: Adds en empty miniOCR as constant and ensure Access Control

### DIFF
--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -2,8 +2,10 @@
 
 namespace Drupal\strawberryfield\Plugin\search_api\datasource;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityDisplayRepositoryInterface;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\TypedData\ComplexDataInterface;
 use Drupal\search_api\Datasource\DatasourcePluginBase;
 use Drupal\search_api\LoggerTrait;
@@ -34,6 +36,13 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
    */
   public const SBFL_KEY_COLLECTION = 'Strawberryfield_flavor_datasource_temp';
 
+  /**
+   * An MINI OCR XML defined for empty pages.
+   */
+  public const EMPTY_MINIOCR_XML = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<ocr><p xml:id="empty_sequence" wh="100 100"><b><l><w x="0 0 0 0"> </w></l></b></p></ocr>
+XML;
 
   /**
    * The entity type manager.
@@ -197,6 +206,19 @@ class StrawberryfieldFlavorDatasource extends DatasourcePluginBase implements St
    */
   public function getItemIds($page = NULL) {
     return $this->getPartialItemIds($page);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getItemAccessResult(ComplexDataInterface $item, AccountInterface $account = NULL) {
+    $entity = $this->getEntity($item);
+    if ($entity) {
+      return $this->getEntityTypeManager()
+        ->getAccessControlHandler($this->getEntityTypeId())
+        ->access($entity, 'view', $account, TRUE);
+    }
+    return AccessResult::neutral('Item is not an entity, so cannot check access');
   }
 
   /**

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -334,10 +334,15 @@ function strawberryfield_s3fs_url_settings_alter(array &$url_settings, $s3_file_
  * accordingly.
  */
 function strawberryfield_search_api_solr_query_alter(SolariumQueryInterface $solarium_query, QueryInterface $query) {
-  // To get a list of solrium events:
+  // To get a list of solarium events:
   // @see http://solarium.readthedocs.io/en/stable/customizing-solarium/#plugin-system
-  // If the Search API query has a 'my_custom_boost' option, use the edsimax
-  // query handler and add some boost queries.
+  if ($query->getOption('no_highlight')) {
+    $solarium_query->addParam('hl', 'false');
+    /* @var \Solarium\Component\Highlighting\Highlighting $hl */
+    $hl = $solarium_query->getHighlighting();
+    $hl->clearFields();
+  }
+
   if ($query->getOption('ocr_highlight')) {
     // $solr_field_names maps search_api field names to real field names in
     // the Solr index.


### PR DESCRIPTION
See #171 and #170 

This adds a constant for empty miniOCRs that can be used by runners or any other (e.g an XML OCR endpoint) and also ensures that we do Access Control on Parent Node.

And extra Search API query option was added (`no_highlight`) to help in cases where we want to programatically call a Solr query, get all Fulltext fields but do not want HL enabled, because without an exact Fulltext field ocrhighlight, as documented, will fail with an "invalid offset" error Solr side.

@giancarlobi you probably need this to test #170 