### PR TITLE
ISSUE-177: Update professional-wiki/edtf version to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "frictionlessdata/datapackage": "dev-master",
         "drupal/search_api": "~1.19",
         "drupal/search_api_solr": "^4.1.10",
-        "professional-wiki/edtf": "0.1.x-dev"
+        "professional-wiki/edtf": "~2.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
See #177 

Version 0.1.0 does not longer exists. That is really bad behavior of that package and they have moved 2 versions in 2 months. Let's catch up. 

Our use is still very discrete so this is not breaking

@patdunlavey thanks for reporting. Can you check this change and approve if you are OK? 