### PR TITLE
ISSUE-180: Refactors ordering for Files +  Minor Computed field fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         }
     ],
     "require": {
+        "php": ">=7.2",
         "ext-json": "*",
         "drupal/core": "^8.9 || ^9",
         "ml/json-ld": "^1.1",

--- a/src/Field/StrawberryFieldEntityComputedItemList.php
+++ b/src/Field/StrawberryFieldEntityComputedItemList.php
@@ -27,7 +27,7 @@ class StrawberryFieldEntityComputedItemList extends EntityReferenceFieldItemList
           // dr:fid.
           if (isset($flatvalues['dr:nid']) && !empty($flatvalues['dr:nid'])) {
             $entity_ids = (array) $flatvalues['dr:nid'];
-            $node_entities = array_filter($entity_ids, 'is_int');
+            $node_entities = array_filter($entity_ids, 'is_scalar');
           }
           // Also get mapped ones
           if (isset($values["ap:entitymapping"]["entity:node"]) &&
@@ -36,15 +36,16 @@ class StrawberryFieldEntityComputedItemList extends EntityReferenceFieldItemList
             foreach ($jsonkeys_with_node_entities as $jsonkey_with_node_entity) {
               if (isset($values[$jsonkey_with_node_entity]) && !empty($values[$jsonkey_with_node_entity])) {
                 $entity_ids = (array) $values[$jsonkey_with_node_entity];
-                $node_entities = array_merge($node_entities, array_filter($entity_ids, 'is_int'));
+                $node_entities = array_merge($node_entities, array_filter($entity_ids, 'is_scalar'));
               }
             }
           }
         }
         // Now see if we got entities
         // I will not deduplicate here since frequency could be a desired factor
+        $node_entities = array_unique($node_entities);
         foreach ($node_entities as $index => $id) {
-          $this->list[$index] = $this->createItem($index, $id);
+          $this->list[$index] = $this->createItem($index, (int) $id);
         }
       }
     }

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -238,7 +238,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
      }
      elseif ($this->validate()->count() == 0) {
        $mainproperty = $this->mainPropertyName();
-       $jsonArray = json_decode($this->{$mainproperty}, $assoc, 50);
+       $jsonArray = json_decode($this->{$mainproperty}, $assoc, 64);
      }
      return $jsonArray;
    }


### PR DESCRIPTION
See #180

New method`::sortFileStructure` for the StrawberryfieldFilePersisterService Services. Gets invoked by the File Structure Generator presave Subscriber.

ADOs SBF JSON's accept now this extra key
```JSON
{
 "ap:tasks": {
        "ap:sortfiles": "manual"
  }
}
}
```
ap:sortfiles can be:
 *  manual (new files will be appended at the end, order of upload is preserved but any manual order given by the user is preserved too)
 * natural (files old and new are always sorted by name of the file inside the as:key"
 * index (files old and new are always sorted by the order of appearance in their respective "source keys", e.g documents, etc (same as show during a webform based edit). Same applies for AMI uploaded files.

Also bumps PHP requirements to >= 7.2


How to test?

- Create a new ADO. Upload a bunch of image files. See how files are being ordered constantly by the `name` key value present inside each `as:image` entry.
- Change on of those via RAW edit. e.g add `a _000` suffix before the file extension. Save. New file should be moved up in the order.
- Edit RAW JSON and change  `"ap:sortfiles": "natural"` to  `"ap:sortfiles": "index"`. Save. Files should be now ordered back into the Upload order.
- Modify one "sequence" value of a single uploaded file (e.g choose the one  that has "sequence":"1") and change to   "sequence":"100". Change `"ap:sortfiles": "index"` to `"ap:sortfiles": "manual"`. Save. See how the previously first image now is the last one.

@patdunlavey @giancarlobi @alliomeria hope this all makes sense
