### PR TITLE
ISSUE-175: First pass (working) on EDTF/ISO8601 validation at Key Name Provider …

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -50,7 +50,10 @@ strawberryfield.strawberry_keynameprovider.jmespath:
   mapping:
     source_key:
       type: string
-      label: 'A Comma separated string containing one or more JMESPaths '
+      label: 'A Comma separated string containing one or more JMESPaths'
+    is_date:
+      type: boolean
+      label: 'If the value should be considered and validated as a date'
     exposed_key:
       type: string
       label: 'The field property we expose for the Strawberryfield'

--- a/src/Plugin/DataType/StrawberryValuesFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesFromJson.php
@@ -36,7 +36,7 @@ class StrawberryValuesFromJson extends ItemList {
    */
   protected $list = [];
   public function getValue() {
-    if ($this->processed == NULL) {
+    if ($this->processed === NULL) {
       $this->process();
     }
     $values = [];
@@ -79,6 +79,7 @@ class StrawberryValuesFromJson extends ItemList {
         $values[] = trim($flattened[$needle]);
       }
       $this->processed = array_values($values);
+      $this->list = [];
       foreach ($this->processed as $delta => $item) {
         $this->list[$delta] = $this->createItem($delta, $item);
       }

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -181,6 +181,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
                ->setReadOnly(TRUE);
            }
            else {
+             $is_date = $plugin_config_entity_configs[$processor_class][$property]['is_date'] ?? FALSE;
              $properties[$property] = ListDataDefinition::create(
                $item_types[$processor_class]
              )
@@ -189,6 +190,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
                ->setClass($processor_class)
                ->setInternal(TRUE)
                ->setSetting('jsonkey', $keyname)
+               ->setSetting('is_date', $is_date)
                ->setReadOnly(TRUE);
            }
          }
@@ -324,7 +326,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
      else {
        if ($this->jsonjmesresults == NULL || !isset($this->jsonjmesresults[$expression]) || $force) {
          $mainproperty = $this->mainPropertyName();
-         $jsonArray = json_decode($this->{$mainproperty}, TRUE, 50);
+         $jsonArray = json_decode($this->{$mainproperty}, TRUE, 64);
          $searchresult = StrawberryfieldJsonHelper::searchJson($expression, $jsonArray);
          $this->jsonjmesresults[$expression] = $searchresult;
          return $searchresult;

--- a/src/Plugin/StrawberryfieldKeyNameProvider/JmesPathNameProvider.php
+++ b/src/Plugin/StrawberryfieldKeyNameProvider/JmesPathNameProvider.php
@@ -48,6 +48,7 @@ class JmesPathNameProvider extends StrawberryfieldKeyNameProviderBase {
         'source_key' => '',
         // Example hocr
         'exposed_key' => '',
+        'is_date' => FALSE,
         // The id of the config entity from where these values came from.'
         'configEntity' => NULL
       ] + parent::defaultConfiguration();
@@ -68,6 +69,15 @@ class JmesPathNameProvider extends StrawberryfieldKeyNameProviderBase {
       '#default_value' => $this->getConfiguration()['source_key'],
       '#description' => $this->t('JMespath(s) will be evaluated against your <em>Strawberry field</em> JSON to extract data.<br> e.g. subject_loc[*].label'),
       '#required' => true,
+    ];
+
+    $element['is_date'] = [
+      '#id' => 'is_date',
+      '#type' => 'checkbox',
+      '#title' => $this->t('Is Date?'),
+      '#default_value' => $this->getConfiguration()['is_date'],
+      '#description' => $this->t('If checked the value coming from your <em>Strawberry field</em> JSON will be validated to be a Date.'),
+      '#required' => FALSE,
     ];
     // We need the parent form structure, if any, to make machine name work.
     $exposed_key_parents = $parents;

--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -351,8 +351,6 @@ class StrawberryfieldJsonHelper {
     return false;
   }
 
-
-
   /**
    *
    *
@@ -363,9 +361,30 @@ class StrawberryfieldJsonHelper {
    * @return mixed|null Returns the matching data or null
    */
   public static function searchJson($expression, array $sourcearray =  []) {
-    return JmesPath::search($expression, $sourcearray);
+    if (!static::jmesPathIsKey($expression)){
+      return JmesPath::search($expression, $sourcearray);
+    }
+    else {
+      $key = trim($expression,'"');
+      return $sourcearray[$key] ?? NULL;
+    }
   }
 
+  /**
+   * Checks if a JMESPath expression is an array key in disguise.
+   * @param $expression
+   *
+   * @return bool
+   */
+  public static function jmesPathIsKey($expression) {
+    $expression = trim($expression, '"');
+     if (preg_match("/(\[|\.|\*)/", $expression)) {
+      return FALSE;
+    }
+    else {
+      return TRUE;
+    }
+  }
 
   /**
    * Takes an array and generates a JMESPath Filter expression


### PR DESCRIPTION
…level
See #175 

@dmer @giancarlobi @patdunlavey, this got me stuck during the RC2. Needed to facet on Dates and for some reason a CSV in the new AMI demo Set had a "full description" inside a  date JSON key in the metadata and Solr Indexing was breaking (bad). 

So i added a checkbox to the `JmesPath`  Key Name provider  (easier than recoding it) and implemented, if that is enabled, (FALSE by default) ETDF/ISO8601 parsing, max and min extraction and indexing back. So if you add a date like 2015-02-02/2020-03-03 it will add both to the facets and index. If the value is totally non-OK and the checkbox is enabled and you Set your Solr to Date for the field, all good. 2015-XX-XX? Also! etc, etc, etc.
Of course if you do not check the box and then force Solr to a date field, it will fail with strings like "the best time of my life" which is a future wish, not a date!

This was the missing piece for the RC2. Now i can sleep