### PR TITLE
ISSUE-184: Adds new data properties to Class StrawberryfieldFlavorDatasource and provide custom Access Control

### DIFF
--- a/src/EventSubscriber/StrawberryEventDeleteFlavorSubscriber.php
+++ b/src/EventSubscriber/StrawberryEventDeleteFlavorSubscriber.php
@@ -42,10 +42,6 @@ class StrawberryEventDeleteFlavorSubscriber extends StrawberryfieldEventDeleteSu
    * {@inheritdoc}
    */
   public function onEntityDelete(StrawberryfieldCrudEvent $event) {
-    // We need to compare the original entity with the saved just now as file
-    // events don't really work for this use case. The file is still attached to
-    // the revisions. This event is run only on update, so we're not treating
-    // the isNew() possibility here.
       $entity = $event->getEntity();
       $this->trackDeleted($entity);
       $current_class = get_called_class();

--- a/src/EventSubscriber/StrawberryEventSaveFlavorSubscriber.php
+++ b/src/EventSubscriber/StrawberryEventSaveFlavorSubscriber.php
@@ -13,9 +13,9 @@ use Drupal\strawberryfield\Tools\Ocfl\OcflHelper;
 use Drupal\search_api\SearchApiException;
 
 /**
- * Event subscriber for SBF bearing entity json process event.
+ * Event subscriber that tracks deleted Files and status updates for Flavors.
  */
-class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEventSaveSubscriber {
+class StrawberryEventSaveFlavorSubscriber extends StrawberryfieldEventSaveSubscriber {
 
   /**
    * {@inheritdoc}
@@ -49,6 +49,7 @@ class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEvent
     // the isNew() possibility here.
     $entity = $event->getEntity();
     $original_entity = $entity->original;
+    $tracked_deleted = [];
 
     // We only care about the original entity ones, so that's the system of
     // record to compare. If $files_deleted is empty, it means new files, or no
@@ -61,8 +62,13 @@ class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEvent
       $file = OcflHelper::resolvetoFIDtoURI($file_id);
       // No need to review if the file is being used somewhere else as we're
       // removing the tracking contextually to the entity.
-      $this->trackFilesDeleted($entity, $file);
+      $tracked_deleted = $this->trackFilesDeleted($entity, $file);
     }
+    if ($entity->isPublished() != $original_entity->isPublished() || $entity->getOwnerId() != $original_entity->getOwnerId()) {
+      $this->trackFlavorsNeedUpdate($entity, $tracked_deleted);
+    }
+
+
     $current_class = get_called_class();
     $event->setProcessedBy($current_class, TRUE);
   }
@@ -74,11 +80,14 @@ class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEvent
    *   The entity to delete flavors contextually.
    * @param \Drupal\file\FileInterface $file
    *   The file associated to the entity.
+   * @return array
+   *    An array of tracked to be deleted Search API entities.
    *
    * @throws \Drupal\search_api\SearchApiException
    */
-  protected function trackFilesDeleted(EntityInterface $entity, FileInterface $file) {
+  protected function trackFilesDeleted(EntityInterface $entity, FileInterface $file): array {
     $datasource_id = 'strawberryfield_flavor_datasource';
+    $tracked_ids = [];
     $limit = 200;
     foreach (StrawberryfieldFlavorDatasource::getValidIndexes() as $index) {
       $query = $index->query(['offset' => 0, 'limit' => $limit]);
@@ -125,6 +134,67 @@ class StrawberryEventSaveFileDeleteFlavorSubscriber extends StrawberryfieldEvent
       }
       catch (SearchApiException $searchApiException) {
         watchdog_exception('strawberryfield', $searchApiException, 'We could not untrack Strawberry Flavor Documents from Index because the Solr Query returned an exception at server level.');
+      }
+    }
+    return $tracked_ids;
+  }
+
+  /**
+   * Track SBF documents to be updated on Search Api.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity to delete flavors contextually.
+   * @param array $deleted_ids
+   *   A list of IDs already tracked to be deleted
+   *
+   * @throws \Drupal\search_api\SearchApiException
+   */
+  protected function trackFlavorsNeedUpdate(EntityInterface $entity, array $deleted_ids) {
+    $datasource_id = 'strawberryfield_flavor_datasource';
+    $limit = 200;
+    foreach (StrawberryfieldFlavorDatasource::getValidIndexes() as $index) {
+      $query = $index->query(['offset' => 0, 'limit' => $limit]);
+      $query->addCondition('search_api_datasource', $datasource_id)
+        ->addCondition('uuid', $entity->uuid());
+      //$query->createConditionGroup()
+      $query->setOption('search_api_retrieved_field_values', ['id']);
+      // Query breaks if not because standard hl is enabled for all fields.
+      // and normal hl offsets on OCR HL specific ones.
+      $query->setOption('ocr_highlight', 'on');
+      // We want all documents removed. No server access needed here.
+      $query->setOption('search_api_bypass_access', TRUE);
+      $query->setProcessingLevel(QueryInterface::PROCESSING_NONE);
+      try {
+        $results = $query->execute();
+        $max = $newcount = $results->getResultCount();
+        $tracked_ids = [];
+        $i = 0;
+        // Only reason we use $newcount and $max is in the rare case
+        // that while untracking deletion is happening in real time
+        // and the actual $newcount decreases "live"
+        while (count($tracked_ids) < $max && $newcount > 0) {
+          $i++;
+          foreach ($results->getResultItems() as $item) {
+            // The tracker methods above prepend the datasource id, so we need to
+            // workaround it by removing it beforehand.
+            [$unused, $raw_id] = Utility::splitCombinedId($item->getId());
+            $tracked_ids[] = $raw_id;
+          }
+          // If there are still more left, change the range and query again.
+          if (count($tracked_ids) < $max) {
+            $query->range($limit * $i, $limit);
+            $results = $query->execute();
+            $newcount = $results->getResultCount();
+          }
+        }
+        // Update after all possible query calls with offsets.
+        $tracked_ids = array_diff($tracked_ids, $deleted_ids);
+        if (count($tracked_ids) > 0) {
+          $index->trackItemsUpdated($datasource_id, $tracked_ids);
+        }
+      }
+      catch (SearchApiException $searchApiException) {
+        watchdog_exception('strawberryfield', $searchApiException, 'We could not update tracking Strawberry Flavor Documents to Index because the Solr Query returned an exception at server level.');
       }
     }
   }

--- a/src/Plugin/DataType/StrawberryfieldFlavorData.php
+++ b/src/Plugin/DataType/StrawberryfieldFlavorData.php
@@ -4,7 +4,6 @@ namespace Drupal\strawberryfield\Plugin\DataType;
 
 use Drupal\Core\TypedData\Plugin\DataType\Map;
 
-
 /**
  * Defines the "StrawberryfieldFlavorData" data type.
  *
@@ -14,4 +13,29 @@ use Drupal\Core\TypedData\Plugin\DataType\Map;
  *  definition_class = "\Drupal\strawberryfield\TypedData\StrawberryfieldFlavorDataDefinition",
  * )
  */
-class StrawberryfieldFlavorData extends Map {}
+class StrawberryfieldFlavorData extends Map {
+
+  /**
+   * Gets the Parent referenced Node Entity or NULL of none.
+   *
+   * This should never return NULL, if so, the parent NODE does no longer exists
+   * And we failed removing it via our events.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+   */
+  public function getParentNode() {
+    if ($this->isEmpty()) {
+      return NULL;
+    }
+    // Being over careful here to not call nested methods if
+    // between results may be null. Better at least here than a try/catch.
+    /** @var \Drupal\Core\Entity\Plugin\DataType\EntityReference|null $target_id */
+    $target_id = $this->get('target_id');
+    $target = $target_id ? $target_id->getTarget() : NULL;
+    /** @var \Drupal\node\NodeInterface|null $node */
+    $node = $target ? $target->getValue() : NULL;
+    return $node;
+  }
+
+}

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -576,9 +576,8 @@ XML;
           $who = isset($processed_data->who) ? (array) $processed_data->who : [];
           $when = isset($processed_data->when) ? (array) $processed_data->when : [];
           $ts = isset($processed_data->ts) ? (string) $processed_data->ts : date("c");
-          $sentiment = isset($processed_data->sentiment) ? (string) $processed_data->sentiment : 0;
+          $sentiment = isset($processed_data->sentiment) ? (is_scalar($processed_data->sentiment) ? $processed_data->sentiment : 0) : 0;
           $uri = isset($processed_data->uri) ? (string) $processed_data->uri : '';
-
           $sequence_total = isset($processed_data->sequence_total) ? (string) $processed_data->sequence_total : $sequence_id;
           if ($checksum) {
             $data = [

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -565,12 +565,15 @@ XML;
           );
           // Put the package File ID / Package.
           $fulltext = isset($processed_data->fulltext) ? (string) $processed_data->fulltext : '';
+          $label = isset($processed_data->label) ? (string) $processed_data->label : "Sequence {$sequence_id}";
           $plaintext = isset($processed_data->plaintext) ? (string) $processed_data->plaintext : '';
+          $metadata = isset($processed_data->metadata) ? (array) $processed_data->metadata : [];
           $checksum = isset($processed_data->checksum) ? (string) $processed_data->checksum : NULL;
           $sequence_total = isset($processed_data->sequence_total) ? (string) $processed_data->sequence_total : $sequence_id;
           if ($checksum) {
             $data = [
               'item_id' => $item_id,
+              'label' =>$label,
               'sequence_id' => $sequence_id,
               'sequence_total' => $sequence_total,
               'target_id' => $splitted_id_for_node[0],
@@ -580,6 +583,7 @@ XML;
               'processor_id' => $plugin_id,
               'fulltext' => '',
               'plaintext' => '',
+              'metadata' => $metadata,
               'checksum' => $checksum,
             ];
             // This will then always create a new Index document, even if empty.

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -198,6 +198,7 @@ XML;
    */
   protected function getEntity(ComplexDataInterface $item) {
     $value = $item->get('target_id')->getValue();
+
     return $value instanceof EntityInterface ? $value : NULL;
   }
 
@@ -547,6 +548,8 @@ XML;
     $keyvalue_collection = self::SBFL_KEY_COLLECTION;
 
     foreach ($this->getEntityStorage()->loadMultiple($entity_ids) as $entity_id => $entity) {
+      $status = $entity->isPublished();
+      $uid = $entity->getOwnerId();
       foreach ($entity_ids_splitted[$entity_id] as $item_id => $splitted_id_for_node) {
         $sequence_id = !empty($splitted_id_for_node[1]) ? $splitted_id_for_node[1] : 1;
         $fid_uuid = isset($splitted_id_for_node[3]) ? $splitted_id_for_node[3] : NULL;
@@ -569,11 +572,18 @@ XML;
           $plaintext = isset($processed_data->plaintext) ? (string) $processed_data->plaintext : '';
           $metadata = isset($processed_data->metadata) ? (array) $processed_data->metadata : [];
           $checksum = isset($processed_data->checksum) ? (string) $processed_data->checksum : NULL;
+          $where = isset($processed_data->where) ? (array) $processed_data->where : [];
+          $who = isset($processed_data->who) ? (array) $processed_data->who : [];
+          $when = isset($processed_data->when) ? (array) $processed_data->when : [];
+          $ts = isset($processed_data->ts) ? (string) $processed_data->ts : date("c");
+          $sentiment = isset($processed_data->sentiment) ? (string) $processed_data->sentiment : 0;
+          $uri = isset($processed_data->uri) ? (string) $processed_data->uri : '';
+
           $sequence_total = isset($processed_data->sequence_total) ? (string) $processed_data->sequence_total : $sequence_id;
           if ($checksum) {
             $data = [
               'item_id' => $item_id,
-              'label' =>$label,
+              'label' => $label,
               'sequence_id' => $sequence_id,
               'sequence_total' => $sequence_total,
               'target_id' => $splitted_id_for_node[0],
@@ -584,7 +594,15 @@ XML;
               'fulltext' => '',
               'plaintext' => '',
               'metadata' => $metadata,
+              'who' => $who,
+              'where' => $where,
+              'when' => $when,
+              'ts' => $ts,
+              'sentiment' => $sentiment,
+              'uri' => $uri,
               'checksum' => $checksum,
+              'status' => $status,
+              'uid' => $uid,
             ];
             // This will then always create a new Index document, even if empty.
             // Needed if we e.g are gonna use this for Book search/IIIF search

--- a/src/Plugin/search_api/processor/StrawberryFlavorContentAccess.php
+++ b/src/Plugin/search_api/processor/StrawberryFlavorContentAccess.php
@@ -1,0 +1,387 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\search_api\processor;
+
+use Drupal\comment\CommentInterface;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
+use Drupal\Core\Session\AnonymousUserSession;
+use Drupal\Core\TypedData\ComplexDataInterface;
+use Drupal\node\NodeInterface;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use \Drupal\strawberryfield\Plugin\DataType\StrawberryfieldFlavorData;
+use Drupal\search_api\IndexInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\LoggerTrait;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\search_api\Query\QueryInterface;
+use Drupal\search_api\SearchApiException;
+use Drupal\user\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Adds content access checks for nodes and comments.
+ *
+ * @SearchApiProcessor(
+ *   id = "sbf_content_access",
+ *   label = @Translation("Content access with Strawberry Flavor data sources awareness"),
+ *   description = @Translation("Adds content access checks for nodes, comments and strawberryflavors like HOCR and WebArchive Indexes. This replaces built in Content Access Processor and should not be used together."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *     "pre_index_save" = -10,
+ *     "preprocess_query" = -30,
+ *   },
+ * )
+ */
+class StrawberryFlavorContentAccess extends ProcessorPluginBase {
+
+  use LoggerTrait;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection|null
+   */
+  protected $database;
+
+  /**
+   * The current_user service used by this plugin.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface|null
+   */
+  protected $currentUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    /** @var static $processor */
+    $processor = parent::create($container, $configuration, $plugin_id, $plugin_definition);
+
+    $processor->setLogger($container->get('logger.channel.search_api'));
+    $processor->setDatabase($container->get('database'));
+    $processor->setCurrentUser($container->get('current_user'));
+
+    return $processor;
+  }
+
+  /**
+   * Retrieves the database connection.
+   *
+   * @return \Drupal\Core\Database\Connection
+   *   The database connection.
+   */
+  public function getDatabase() {
+    return $this->database ?: \Drupal::database();
+  }
+
+  /**
+   * Sets the database connection.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   The new database connection.
+   *
+   * @return $this
+   */
+  public function setDatabase(Connection $database) {
+    $this->database = $database;
+    return $this;
+  }
+
+  /**
+   * Retrieves the current user.
+   *
+   * @return \Drupal\Core\Session\AccountProxyInterface
+   *   The current user.
+   */
+  public function getCurrentUser() {
+    return $this->currentUser ?: \Drupal::currentUser();
+  }
+
+  /**
+   * Sets the current user.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $current_user
+   *   The current user.
+   *
+   * @return $this
+   */
+  public function setCurrentUser(AccountProxyInterface $current_user) {
+    $this->currentUser = $current_user;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function supportsIndex(IndexInterface $index) {
+    foreach ($index->getDatasources() as $datasource) {
+      if (in_array($datasource->getEntityTypeId(), ['node', 'comment'])) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $definition = [
+        'label' => $this->t('Node access information'),
+        'description' => $this->t('Data needed to apply node access.'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+        'hidden' => TRUE,
+        'is_list' => TRUE,
+      ];
+      $properties['search_api_node_grants'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    static $anonymous_user;
+
+    if (!isset($anonymous_user)) {
+      // Load the anonymous user.
+      $anonymous_user = new AnonymousUserSession();
+    }
+
+    // Only run for node and comment items.
+    $entity_type_id = $item->getDatasource()->getEntityTypeId();
+    if (!in_array($entity_type_id, ['node', 'comment'])) {
+      return;
+    }
+
+    // Get the node object.
+    $original_object = $item->getOriginalObject();
+    $node = $this->getNode($original_object);
+    if (!$node) {
+      // Apparently we were active for a wrong item.
+      return;
+    }
+
+    $fields = $item->getFields();
+    $fields = $this->getFieldsHelper()
+      ->filterForPropertyPath($fields, NULL, 'search_api_node_grants');
+    foreach ($fields as $field) {
+      // Collect grant records for the node. If there are none, use the pseudo
+      // grant "node_access__all".
+      $sql = 'SELECT gid, realm FROM {node_access} WHERE (nid = 0 OR nid = :nid) AND grant_view = 1';
+      $args = [':nid' => $node->id()];
+      $grant_records = $this->getDatabase()->query($sql, $args)->fetchAll();
+      if ($grant_records) {
+        foreach ($grant_records as $grant) {
+          $field->addValue("node_access_{$grant->realm}:{$grant->gid}");
+        }
+      }
+      else {
+        // Add the generic pseudo view grant if we are not using node access.
+        $field->addValue('node_access__all');
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preIndexSave() {
+    foreach ($this->index->getDatasources() as $datasource_id => $datasource) {
+      $entity_type = $datasource->getEntityTypeId();
+      if (in_array($entity_type, ['node', 'comment'])) {
+        $this->ensureField($datasource_id, 'status', 'boolean');
+        if ($entity_type == 'node') {
+          $this->ensureField($datasource_id, 'uid', 'integer');
+        }
+      }
+    }
+
+    $field = $this->ensureField(NULL, 'search_api_node_grants', 'string');
+    $field->setHidden();
+  }
+
+  /**
+   * Retrieves the node related to an indexed search object.
+   *
+   * Will be either the node itself, or the node the comment is attached to.
+   *
+   * @param \Drupal\Core\TypedData\ComplexDataInterface $item
+   *   A search object that is being indexed.
+   *
+   * @return \Drupal\node\NodeInterface|null
+   *   The node related to that search object.
+   */
+  protected function getNode(ComplexDataInterface $item) {
+
+    if ($item instanceof StrawberryfieldFlavorData) {
+      $item = $item->getParentNode();
+    }
+    else  {
+      $item = $item->getValue();
+    }
+    if ($item instanceof CommentInterface) {
+      $item = $item->getCommentedEntity();
+    }
+    if ($item instanceof NodeInterface) {
+      return $item;
+    }
+
+    return NULL;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function preprocessSearchQuery(QueryInterface $query) {
+    if (!$query->getOption('search_api_bypass_access')) {
+      $account = $query->getOption('search_api_access_account', $this->getCurrentUser());
+      if (is_numeric($account)) {
+        $account = User::load($account);
+      }
+      if ($account instanceof AccountInterface) {
+        try {
+          $this->addNodeAccess($query, $account);
+        }
+        catch (SearchApiException $e) {
+          $this->logException($e);
+        }
+      }
+      else {
+        $account = $query->getOption('search_api_access_account', $this->getCurrentUser());
+        if ($account instanceof AccountInterface) {
+          $account = $account->id();
+        }
+        if (!is_scalar($account)) {
+          $account = var_export($account, TRUE);
+        }
+        $this->getLogger()->warning('An illegal user UID was given for node access: @uid.', ['@uid' => $account]);
+      }
+    }
+  }
+
+  /**
+   * Adds a node access filter to a search query, if applicable.
+   *
+   * @param \Drupal\search_api\Query\QueryInterface $query
+   *   The query to which a node access filter should be added, if applicable.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The user for whom the search is executed.
+   *
+   * @throws \Drupal\search_api\SearchApiException
+   *   Thrown if not all necessary fields are indexed on the index.
+   */
+  protected function addNodeAccess(QueryInterface $query, AccountInterface $account) {
+    // Don't do anything if the user can access all content.
+    if ($account->hasPermission('bypass node access')) {
+      return;
+    }
+
+    // Gather the affected datasources, grouped by entity type, as well as the
+    // unaffected ones.
+    $affected_datasources = [];
+    $unaffected_datasources = [];
+    foreach ($this->index->getDatasources() as $datasource_id => $datasource) {
+      $entity_type = $datasource->getEntityTypeId();
+      if (in_array($entity_type, ['node', 'comment'])) {
+        $affected_datasources[$entity_type][] = $datasource_id;
+      }
+      else {
+        $unaffected_datasources[] = $datasource_id;
+      }
+    }
+
+    // The filter structure we want looks like this:
+    //   [belongs to other datasource]
+    //   OR
+    //   (
+    //     [is enabled (or was created by the user, if applicable)]
+    //     AND
+    //     [grants view access to one of the user's gid/realm combinations]
+    //   )
+    // If there are no "other" datasources, we don't need the nested OR,
+    // however, and can add the inner conditions directly to the query.
+    if ($unaffected_datasources) {
+      $outer_conditions = $query->createConditionGroup('OR', ['content_access']);
+      $query->addConditionGroup($outer_conditions);
+      foreach ($unaffected_datasources as $datasource_id) {
+        $outer_conditions->addCondition('search_api_datasource', $datasource_id);
+      }
+      $access_conditions = $query->createConditionGroup('AND');
+      $outer_conditions->addConditionGroup($access_conditions);
+    }
+    else {
+      $access_conditions = $query;
+    }
+
+    if (!$account->hasPermission('access content')) {
+      unset($affected_datasources['node']);
+    }
+    if (!$account->hasPermission('access comments')) {
+      unset($affected_datasources['comment']);
+    }
+
+    // If the user does not have the permission to see any content at all, deny
+    // access to all items from affected datasources.
+    if (!$affected_datasources) {
+      // If there were "other" datasources, the existing filter will already
+      // remove all results of node or comment datasources. Otherwise, we should
+      // not return any results at all.
+      if (!$unaffected_datasources) {
+        $query->abort($this->t('You have no access to any results in this search.'));
+      }
+      return;
+    }
+
+    // Collect all the required fields that need to be part of the index.
+    $unpublished_own = $account->hasPermission('view own unpublished content');
+
+    $enabled_conditions = $query->createConditionGroup('OR', ['content_access_enabled']);
+    foreach ($affected_datasources as $entity_type => $datasources) {
+      foreach ($datasources as $datasource_id) {
+        // If this is a comment datasource, or users cannot view their own
+        // unpublished nodes, a simple filter on "status" is enough. Otherwise,
+        // it's a bit more complicated.
+        $status_field = $this->findField($datasource_id, 'status', 'boolean');
+        if ($status_field) {
+          $enabled_conditions->addCondition($status_field->getFieldIdentifier(), TRUE);
+        }
+        if ($entity_type == 'node' && $unpublished_own) {
+          $author_field = $this->findField($datasource_id, 'uid', 'integer');
+          if ($author_field) {
+            $enabled_conditions->addCondition($author_field->getFieldIdentifier(), $account->id());
+          }
+        }
+      }
+    }
+    $access_conditions->addConditionGroup($enabled_conditions);
+
+    // Filter by the user's node access grants.
+    $node_grants_field = $this->findField(NULL, 'search_api_node_grants', 'string');
+    if (!$node_grants_field) {
+      return;
+    }
+    $node_grants_field_id = $node_grants_field->getFieldIdentifier();
+    $grants_conditions = $query->createConditionGroup('OR', ['content_access_grants']);
+    $grants = node_access_grants('view', $account);
+    foreach ($grants as $realm => $gids) {
+      foreach ($gids as $gid) {
+        $grants_conditions->addCondition($node_grants_field_id, "node_access_$realm:$gid");
+      }
+    }
+    // Also add items that are accessible for everyone by checking the "access
+    // all" pseudo grant.
+    $grants_conditions->addCondition($node_grants_field_id, 'node_access__all');
+    $access_conditions->addConditionGroup($grants_conditions);
+  }
+
+}

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -545,6 +545,7 @@ class StrawberryfieldFilePersisterService {
           'dr:for' => $file_source_key,
           'dr:fid' => (int) $file->id(),
           'dr:uuid' => $uuid,
+          'dr:filesize' => (int) $file->getSize(),
           'dr:mimetype' => $mime,
           'name' => $file->getFilename(),
           'tags' => [],

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -45,6 +45,11 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info['fulltext'] = DataDefinition::create('string')->setLabel('Unmodified data body');
       $info['plaintext'] = DataDefinition::create('string')->setLabel('Data body containing un formatted text from fulltext');
       $info['metadata'] = ListDataDefinition::create('string')->setLabel('Ordered list of additional metadata');
+      $info['who'] = ListDataDefinition::create('string')->setLabel('Ordered list of agents');
+      $info['where'] = ListDataDefinition::create('string')->setLabel('Ordered list of places');
+      $info['when'] = ListDataDefinition::create('string')->setLabel('Ordered list of dates in string format');
+      $info['sentiment'] = DataDefinition::create('string')->setLabel('Sentiment in integer range');
+      $info['ts'] = DataDefinition::create('string')->setLabel('A Time stamp');
       //§/ required by Content Access processor , maybe we can disable it in some manner
       $info['status'] = DataDefinition::create('boolean')->setLabel('Status');
       $info['uid'] = DataDefinition::create('integer')->setLabel('UID');

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -7,6 +7,7 @@ use Drupal\Core\TypedData\DataDefinition;
 use Drupal\Core\TypedData\DataReferenceTargetDefinition;
 use Drupal\Core\Entity\TypedData\EntityDataDefinition;
 use Drupal\Core\TypedData\DataReferenceDefinition;
+use Drupal\Core\TypedData\ListDataDefinition;
 
 /**
  * A typed data definition class for describing SBF Flavor Data Sources .
@@ -20,6 +21,7 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
     if(!isset($this->propertyDefinitions)){
       $info = &$this->propertyDefinitions;
       $info['item_id'] = DataDefinition::create('string')->setLabel('Item ID');
+      $info['label'] = DataDefinition::create('string')->setLabel('A Label');
       $info['sequence_id'] = DataDefinition::create('string')->setLabel('Sequence ID');
       $info['sequence_total'] = DataDefinition::create('string')->setLabel('Expected total sequence count');
       $info['uri'] = DataDefinition::create('string')->setLabel('A source or related Uri/URL');
@@ -42,6 +44,7 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
         ->addConstraint('EntityType', 'file');
       $info['fulltext'] = DataDefinition::create('string')->setLabel('Unmodified data body');
       $info['plaintext'] = DataDefinition::create('string')->setLabel('Data body containing un formatted text from fulltext');
+      $info['metadata'] = ListDataDefinition::create('string')->setLabel('Ordered list of additional metadata');
       //§/ required by Content Access processor , maybe we can disable it in some manner
       $info['status'] = DataDefinition::create('boolean')->setLabel('Status');
       $info['uid'] = DataDefinition::create('integer')->setLabel('UID');

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -50,8 +50,8 @@ services:
     tags:
       - {name: event_subscriber}
     arguments: ['@string_translation', '@messenger', '@logger.factory', '@strawberryfield.file_persister', '@current_user']
-  strawberryfield.file_delete_flavor:
-    class: Drupal\strawberryfield\EventSubscriber\StrawberryEventSaveFileDeleteFlavorSubscriber
+  strawberryfield.node_update_flavor:
+    class: Drupal\strawberryfield\EventSubscriber\StrawberryEventSaveFlavorSubscriber
     tags:
       - { name: event_subscriber }
     arguments: ['@keyvalue']


### PR DESCRIPTION
See #184 

`Label` and `Metadata`, `ts`, `url`, `sentiment`, `who`, `where` and `when` are the new ones. Will come handy in the future (near future)

Will test if original functionality is not affected and will go from there. This is the first step into RC3 and will also include once tested the new reactPHP code Giancarlo did to enhance the experience


Also includes Access Control processor (replacement for the Core one) that knows how to handle Strawberry Flavors (so full status connection between Nodes and its HOCR) and some extra goodies like automatic updates on Strawberry Flavor Solr Indexed Documents(HOCR when the Node changes user/status).

This comes with an extra pull from Strawberry Runners but does not require it.
