### PR TITLE
Issue 175b: make date/time parsing even more flexible in our JmesPath keyname provider

### DIFF
--- a/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
@@ -6,6 +6,7 @@
  * Time: 8:21 PM
  */
 namespace Drupal\strawberryfield\Plugin\DataType;
+use DateTime;
 use Drupal\Core\TypedData\Plugin\DataType\ItemList;
 use Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem;
 use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
@@ -98,6 +99,11 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
             $date_max = date('c', $date_max);
             $values_parsed[] = $date_ini;
             $values_parsed[] = $date_max;
+          }
+          else {
+            // If not EDTF (e.g an already ISO8601 date)
+            // try with string based parsing
+            $values_parsed[] = $this->parseStringToDate($value);
           }
         }
         $values = array_unique($values_parsed);
@@ -199,6 +205,33 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
    */
   public function applyDefaultValue($notify = TRUE) {
     return $this;
+  }
+
+  /**
+   * Will try to parse an unknown string to an ISO8601 date.
+   *
+   * @param mixed $date
+   *
+   * @return false|string
+   *    If string/int could not be parse returns false.
+   *    If it was possible, return an ISO8601 date.
+   */
+  protected function parseStringToDate($date) {
+    // Start by using a full ISO8601 date in case time zone is included
+    $d = DateTime::createFromFormat('c', $date);
+    if (!$d) {
+      // If not check if its not a timestamp
+      if (!is_numeric($date)) {
+        $date = strtotime($date);
+      }
+      if ($date) {
+        $d = DateTime::createFromFormat('U', $date);
+      }
+    }
+    if ($d) {
+      return $d->format('c');
+    }
+    return FALSE;
   }
 }
 


### PR DESCRIPTION
# What?

As @alliomeria and I discovered today, if your webform has actual ISO8601 dates formatted (storing in JSON) the EDTF formatter will kinda give up. This better approach (which I'm sure I coded already in the past but can't find where/how? why am I so tired all the time?) tries in case of an EDTF failure with a direct PHP string to Date approach. How?

# How?

- First we try assuming the date is already ISO8601 ('c' format). Why? because in the next step I will convert all into a UNIX Timestamp and as you well know Unix TimeStamps have no Time Zones (and ISO8601 has).
- If this fails we check if not numeric. Why? because next step deals with all except with timestamps. 
- If not numeric we go with a strtotime() which will accept things like "yesterday", "tomorrow", "2022", "1917-01", etc. and will return a timestamp
- If there is a timestamp we cast now back into ISO8601 and return that
- If all failed we return FALSE and assume this was really never a time crystal
@aksm for your eyes too. @patdunlavey you may want to read this too