### PR TITLE
ISSUE-207 --- proposed fix for EDTF parsing problem with open range interval dates

### DIFF
--- a/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
@@ -101,7 +101,7 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
             $edtf_value = $result->getEdtfValue();
             switch(get_class($edtf_value)) {
               case "EDTF\Model\Interval":
-                if($result->getEdtfValue()->hasStartDate()) {
+                if($edtf_value->hasStartDate()) {
                   $values_parsed[] = date('c', $edtf_value->getMin());
                 }
                 if($result->getEdtfValue()->hasEndDate()) {

--- a/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
@@ -86,7 +86,7 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
       // This is an array, don't double nest to make the normalizer happy.
       $jmespath_result_to_expose = array_filter($jmespath_result_to_expose);
       foreach($jmespath_result_to_expose as $i => $v) {
-        if(!is_string($v)) {
+        if(is_array($v) or is_object($v)) {
           $jmespath_result_to_expose[$i] = json_encode($v);
         }
       }
@@ -99,12 +99,13 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
           $result = $parser->parse($value);
           if ($result->isValid()) {
             $edtf_value = $result->getEdtfValue();
+            // @todo remove once EDTF fixes their invalid Constructor for EDTF\Model\Interval that should per interface never allow NULL for start nor end date
             switch(get_class($edtf_value)) {
               case "EDTF\Model\Interval":
                 if($edtf_value->hasStartDate()) {
                   $values_parsed[] = date('c', $edtf_value->getMin());
                 }
-                if($result->getEdtfValue()->hasEndDate()) {
+                if($edtf_value->hasEndDate()) {
                   $values_parsed[] = date('c', $edtf_value->getMax());
                 }
                 break;


### PR DESCRIPTION
also includes fix for cases when the jmespath_result is not a string (when the value in the field was json_decoded to an array).

See discussion here: https://github.com/esmero/strawberryfield/issues/207