### PR TITLE
ISSUE-210: add timeout argument to Hydroponics

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -219,7 +219,10 @@ strawberryfield.hydroponics_settings:
   mapping:
     active:
       type: boolean
-      label: If Hydroponics Service is enabled or not
+      label: 'If Hydroponics Service is enabled or not'
+    time_to_expire:
+      type: integer
+      label: 'How long Hydroponics Service should stay awake, 0 means until done with all queues'
     drush_path:
       type: string
       label: 'Full system path to the /vendor composer Drush installation including drush script'

--- a/src/Commands/HydroponicsDrushCommands.php
+++ b/src/Commands/HydroponicsDrushCommands.php
@@ -11,7 +11,7 @@ namespace Drupal\strawberryfield\Commands;
 use Drush\Commands\DrushCommands;
 use Drush\Exec\ExecTrait;
 use Drush\Runtime\Runtime;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 
 /**
@@ -37,7 +37,7 @@ class HydroponicsDrushCommands extends DrushCommands {
   public function hydroponics(
   ) {
 
-    $loop = Factory::create();
+    $loop = Loop::get();
     $timer_ping = $loop->addPeriodicTimer(3.0, function () {
       // store a heartbeat every 3 seconds.
       $currenttime = \Drupal::time()->getCurrentTime();
@@ -106,22 +106,30 @@ class HydroponicsDrushCommands extends DrushCommands {
         \Drupal::logger('hydroponics')->info("All queues are idle, closing timers");
 
         $loop->cancelTimer($timer);
+        $loop->stop();
         }
       }
     );
-
-    $securitytimer = $loop->addTimer(720.0, function ($timer) use ($loop, $timer_ping, $idle_timer, &$done) {
-      // Finish all if 720 seconds are reached
-      \Drupal::logger('hydroponics')->info("720 seconds passed closing Hydroponics Service");
-      $loop->cancelTimer($timer_ping);
-      foreach($done as $queue_timer) {
-        $loop->cancelTimer($queue_timer);
-      }
-      \Drupal::state()->set('hydroponics.queurunner_last_pid', 0);
-      $loop->cancelTimer($idle_timer);
-      $loop->stop();
-      }
-    );
+    $time_to_expire = (int) \Drupal::config('strawberryfield.hydroponics_settings')->get('time_to_expire');
+    if ($time_to_expire > 0 ) {
+      $time_to_expire = round($time_to_expire, 1);
+      $securitytimer = $loop->addTimer($time_to_expire,
+        function ($timer) use ($loop, $timer_ping, $idle_timer, &$done, $time_to_expire) {
+          // Finish all if 720 seconds are reached
+          \Drupal::logger('hydroponics')
+            ->info("@time_to_expire seconds passed closing Hydroponics Service", [
+              '@time_to_expire' => $time_to_expire,
+            ]);
+          $loop->cancelTimer($timer_ping);
+          foreach ($done as $queue_timer) {
+            $loop->cancelTimer($queue_timer);
+          }
+          \Drupal::state()->set('hydroponics.queurunner_last_pid', 0);
+          $loop->cancelTimer($idle_timer);
+          $loop->stop();
+        }
+      );
+    }
 
     /* TODO recompile with PCNTL enabled
     \pcntl_signal(SIGINT, 'signalhandler');

--- a/src/Commands/HydroponicsDrushCommands.php
+++ b/src/Commands/HydroponicsDrushCommands.php
@@ -115,7 +115,7 @@ class HydroponicsDrushCommands extends DrushCommands {
       $time_to_expire = round($time_to_expire, 1);
       $securitytimer = $loop->addTimer($time_to_expire,
         function ($timer) use ($loop, $timer_ping, $idle_timer, &$done, $time_to_expire) {
-          // Finish all if 720 seconds are reached
+          // Finish all if Time to live in seconds is reached
           \Drupal::logger('hydroponics')
             ->info("@time_to_expire seconds passed closing Hydroponics Service", [
               '@time_to_expire' => $time_to_expire,

--- a/src/Form/HydroponicsSettingsForm.php
+++ b/src/Form/HydroponicsSettingsForm.php
@@ -133,6 +133,7 @@ class HydroponicsSettingsForm extends ConfigFormBase implements ContainerInjecti
     $config = $this->config('strawberryfield.hydroponics_settings');
 
     $active =  $config->get('active') ? $config->get('active') : FALSE;
+    $time_to_expire =  $config->get('time_to_expire') ? $config->get('time_to_expire') : 720;
     $drush_path = $config->get('drush_path') ?  $config->get('drush_path') : NULL;
     $home_path = $config->get('home_path') ?  $config->get('home_path') : NULL;
     $enabled_queues =  !empty($config->get('queues')) ? array_flip($config->get('queues')) : [];
@@ -177,6 +178,17 @@ class HydroponicsSettingsForm extends ConfigFormBase implements ContainerInjecti
       '#required' => FALSE,
       '#default_value' => $active,
     ];
+
+    $form['time_to_expire'] = [
+      '#title' => 'Time to live (stay awake) for the Hydroponics Service.',
+      '#description' => 'A value of 0 will force the Service to finish all pending queues before shutting down',
+      '#type' => 'number',
+      '#step' => 60,
+      '#min' => 0,
+      '#required' => TRUE,
+      '#default_value' => $time_to_expire,
+    ];
+
     $form['advanced'] =  [
       '#type' => 'details',
       '#title' => 'Advanced settings',
@@ -307,6 +319,7 @@ class HydroponicsSettingsForm extends ConfigFormBase implements ContainerInjecti
     $global_active = (bool) $form_state->getValue('active');
     $drush_path = rtrim($form_state->getValue('drush_path'), '/');
     $home_path = rtrim($form_state->getValue('home_path'), '/');
+    $time_to_expire = (int) trim($form_state->getValue('time_to_expire', 720));
     foreach($form_state->getValue('table-row') as $queuename => $queue) {
       if ($queue['active'] == 1) {
         $enabled[] = $queuename;
@@ -318,6 +331,7 @@ class HydroponicsSettingsForm extends ConfigFormBase implements ContainerInjecti
       ->set('drush_path', $drush_path)
       ->set('home_path', $home_path)
       ->set('queues', $enabled)
+      ->set('time_to_expire', $time_to_expire)
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/src/Form/HydroponicsSettingsForm.php
+++ b/src/Form/HydroponicsSettingsForm.php
@@ -133,7 +133,7 @@ class HydroponicsSettingsForm extends ConfigFormBase implements ContainerInjecti
     $config = $this->config('strawberryfield.hydroponics_settings');
 
     $active =  $config->get('active') ? $config->get('active') : FALSE;
-    $time_to_expire =  $config->get('time_to_expire') ? $config->get('time_to_expire') : 720;
+    $time_to_expire =  $config->get('time_to_expire') !== null ? $config->get('time_to_expire') : 720;
     $drush_path = $config->get('drush_path') ?  $config->get('drush_path') : NULL;
     $home_path = $config->get('home_path') ?  $config->get('home_path') : NULL;
     $enabled_queues =  !empty($config->get('queues')) ? array_flip($config->get('queues')) : [];

--- a/src/Plugin/Action/StrawberryfieldJsonPatch.php
+++ b/src/Plugin/Action/StrawberryfieldJsonPatch.php
@@ -281,6 +281,14 @@ JSON;
 
           ]);
           if (!$this->configuration['simulate']) {
+            if ($entity->getEntityType()->isRevisionable()) {
+              // Forces a New Revision for Not-create Operations.
+              $entity->setNewRevision(TRUE);
+              $entity->setRevisionCreationTime(\Drupal::time()->getRequestTime());
+              // Set data for the revision
+              $entity->setRevisionLogMessage('ADO modified via JSON Patch Search And Replace with Patch:'. $this->configuration['jsonpatch']);
+              $entity->setRevisionUserId($this->currentUser->id());
+            }
             $entity->save();
           }
         }


### PR DESCRIPTION
See #210. Yes my branch is incorrectly named, but Github crashed, not my fault! (well it is my fault)

This adds a Time To Live argument for Hydroponics. When set to 0, it will process until all queues are done, no exception. The default value is still 720 seconds as before and can be modified in 60 seconds increments. Also updates how the loop is created removing a deprecated factory:: call.

Additional. Forces revisions on JSON Patch derived operations.
