### PR TITLE
ISSUE-215: Add S3 remote check and improve mediainfo/flattening + sanity

### DIFF
--- a/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
+++ b/src/EventSubscriber/StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator.php
@@ -291,13 +291,19 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
 
     $jsonkeys_with_fileids_clean = [];
 
-    if (!isset($fullvalues['ap:entitymapping']['entity:file']) && !empty($for_from_as)) {
+    // Only try this once we are sure $fullvalues['ap:entitymapping']
+    // Is already an array (no string offsets) or not there at all
+    if (((is_array($fullvalues['ap:entitymapping']) &&
+      !isset($fullvalues['ap:entitymapping']['entity:file'])) ||
+      empty($fullvalues['ap:entitymapping']))
+       && is_array($for_from_as) && !empty($for_from_as)) {
       $fullvalues['ap:entitymapping']['entity:file'] = $for_from_as;
     }
 
     if (isset($fullvalues['ap:entitymapping']) && is_array(
         $fullvalues['ap:entitymapping']
       )) {
+
       $entityMapping = array_filter(
         $fullvalues['ap:entitymapping'],
         [$this,'prefixedEntity'],
@@ -311,7 +317,6 @@ class StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator extends Stra
             [$this, 'isNotArray']
           );
         }
-
 
         if (is_array($jsonkeys_with_fileids_clean)) {
           // Clean again in case we have an empty mapping, like entity:node?

--- a/src/StrawberryfieldFileMetadataService.php
+++ b/src/StrawberryfieldFileMetadataService.php
@@ -605,7 +605,18 @@ class StrawberryfieldFileMetadataService {
       $mediaInfo->setConfig('command', $exec_path);
       try {
         $mediaInfoContainer = $mediaInfo->getInfo($templocation, TRUE);
-        $metadata['flv:mediainfo'] = $mediaInfoContainer->__toArray();
+        $metadata['flv:mediainfo'] = $mediaInfoContainer ?? [];
+        $metadata['flv:mediainfo'] = json_decode(json_encode($metadata['flv:mediainfo']), TRUE);
+        if ($error = json_last_error()) {
+          $metadata['flv:mediainfo'] = [];
+          $this->loggerFactory->get('strawberryfield')->warning(
+            'Could not process MediaInfo on @templocation for @fileurl',
+            [
+              '@fileurl' => $file->getFileUri(),
+              '@templocation' => $templocation,
+            ]
+          );
+        }
         if ($reduced) {
           // These are the basics needed to construct a IIIF Manifest.
           $temp['videos'][0]['width']['absoluteValue'] = $metadata['flv:mediainfo']['videos'][0]['width']['absoluteValue'] ?? NULL;


### PR DESCRIPTION
See #215 

This adds a new remote S3 head/check if there/checksum method that does not depend on S3FS caching.
We also flatten mediainfo response immediately in case we need to do a JSON PATCH in the future (swagger/json* diff and stuff can only act on native JSON and not PHP objects that implement to array methods (Thanks @patdunlavey for finding this)

Finally we ALWAYS take over files that live in temporary:// independently of their status. This will allow temps to be set as permanent and still be managed/counted/moved by SBF


