### PR TITLE
ISSUE-217: Fixes non sense logic for updating/removing left over SBFlavor docs

### DIFF
--- a/src/EventSubscriber/StrawberryEventSaveFlavorSubscriber.php
+++ b/src/EventSubscriber/StrawberryEventSaveFlavorSubscriber.php
@@ -62,12 +62,16 @@ class StrawberryEventSaveFlavorSubscriber extends StrawberryfieldEventSaveSubscr
       $file = OcflHelper::resolvetoFIDtoURI($file_id);
       // No need to review if the file is being used somewhere else as we're
       // removing the tracking contextually to the entity.
-      $tracked_deleted = $this->trackFilesDeleted($entity, $file);
+      if ($file) {
+        $tracked_deleted = array_merge($tracked_deleted, $this->trackFilesDeleted($entity, $file));
+      }
     }
+
+    $tracked_deleted = array_unique($tracked_deleted);
+
     if ($entity->isPublished() != $original_entity->isPublished() || $entity->getOwnerId() != $original_entity->getOwnerId()) {
       $this->trackFlavorsNeedUpdate($entity, $tracked_deleted);
     }
-
 
     $current_class = get_called_class();
     $event->setProcessedBy($current_class, TRUE);

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -579,6 +579,10 @@ XML;
           $sentiment = isset($processed_data->sentiment) ? (is_scalar($processed_data->sentiment) ? $processed_data->sentiment : 0) : 0;
           $uri = isset($processed_data->uri) ? (string) $processed_data->uri : '';
           $sequence_total = isset($processed_data->sequence_total) ? (string) $processed_data->sequence_total : $sequence_id;
+          $sequence_id = isset($processed_data->sequence_id) ? (int) $processed_data->sequence_id : $sequence_id;
+          $config_processor_id = isset($processed_data->config_processor_id) ? $processed_data->config_processor_id : '';
+          $nlplang = isset($processed_data->nlplang) ? $processed_data->nlplang : [];
+          $processlang = isset($processed_data->processlang) ? $processed_data->processlang : [];
           if ($checksum) {
             $data = [
               'item_id' => $item_id,
@@ -589,11 +593,14 @@ XML;
               'parent_id' => $splitted_id_for_node[0],
               'file_uuid' => $fid_uuid,
               'target_fileid' => $file->id(),
+              'config_processor_id' => $config_processor_id,
               'processor_id' => $plugin_id,
               'fulltext' => '',
               'plaintext' => '',
               'metadata' => $metadata,
               'who' => $who,
+              'nlplang' => $nlplang,
+              'processlang' => $processlang,
               'where' => $where,
               'when' => $when,
               'ts' => $ts,

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -49,6 +49,8 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info['where'] = ListDataDefinition::create('string')->setLabel('Ordered list of places');
       $info['when'] = ListDataDefinition::create('string')->setLabel('Ordered list of dates in string format');
       $info['sentiment'] = DataDefinition::create('string')->setLabel('Sentiment in integer range');
+      $info['nlplang'] = ListDataDefinition::create('string')->setLabel('Ordered list of nlp detected languages');
+      $info['processlang'] = ListDataDefinition::create('string')->setLabel('Ordered list of languages provided to process nnmodified data body');
       $info['ts'] = DataDefinition::create('string')->setLabel('A Time stamp');
       //§/ required by Content Access processor , maybe we can disable it in some manner
       $info['status'] = DataDefinition::create('boolean')->setLabel('Status');


### PR DESCRIPTION
See #217 

Also. This enables 2x new properties that can go into Solr, `nlplang` and `processlang`
- `nlplang`: Language detected during OCR/WACZ page extraction
- `processlang`: Language requested from defaults or metadata for OCR