### PR TITLE
ISSUE-222: Composer bin service. Enqueue and delete temp files

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -258,6 +258,6 @@ strawberryfield.breadcrumb_settings:
       label: 'Type of Breadcrumb to process for ADOs'
       default: 'longest'
     enabled:
-      type: boolan
+      type: boolean
       label: 'If Breadcrumb processing is enabled or not'
       default: TRUE

--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -93,6 +93,10 @@ strawberryfield.storage_settings:
       type: string
       label: 'Storage Path under the Storage Scheme, for Persisting Digital Objects in JSON format'
       default: "dostorage"
+    compost_maximum_age:
+      type: integer
+      label: 'Max time to live of Archipelago generated Temporary Files'
+      default: 21600
 
 strawberryfield.archipelago_solr_settings:
   type: config_object

--- a/src/Event/StrawberryfieldFileEvent.php
+++ b/src/Event/StrawberryfieldFileEvent.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Drupal\strawberryfield\Event;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Drupal\Component\EventDispatcher\Event;
+
+/**
+ * File Event. Works on File paths/urls, not File Entities.
+ */
+class StrawberryfieldFileEvent extends Event {
+
+
+  /**
+   * The Path with StreamWrapper to a File.
+   *
+   * @var string
+   */
+  private string $uri;
+
+
+  /**
+   * The Time this event was Fired
+   *
+   * @var integer
+   */
+  private int $timestamp;
+
+
+  /**
+   * The Drupal Module machine name that triggered this event.
+   *
+   * @var string
+   */
+  private $module;
+
+  /**
+   * The event type.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldEventType
+   */
+  private $eventType;
+
+
+  /**
+   * Which Subscribers processed this Event.
+   *
+   * @var array
+   *
+   */
+  private $processedby = [];
+
+  /**
+   * Construct a new entity event.
+   *
+   * @param string $event_type
+   *   The event type.
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   The entity which caused the event.
+   */
+  public function __construct($event_type, $module, $uri, $timestamp,  array $processedby = []) {
+    $this->eventType = $event_type;
+    $this->uri = $uri;
+    $this->timestamp = $timestamp;
+    $this->module = $module;
+    $this->processedby = $processedby;
+  }
+
+  /**
+   * Method to get the URL from the event.
+   */
+  public function getURI() {
+    return $this->uri;
+  }
+
+
+  /**
+   * Method to get the Timestamp from the event.
+   */
+  public function getTimeStamp() {
+    return $this->timestamp;
+  }
+  /**
+   * Method to get triggering Module from the event.
+   */
+  public function getModule() {
+    return $this->module;
+  }
+
+  /**
+   * Method to get the event type.
+   */
+  public function getEventType() {
+    return $this->eventType;
+  }
+  /**
+   * Method to get the all Subscribers that processed this in the past.
+   */
+  public function getProcessedBy() {
+    return $this->processedby;
+  }
+  /**
+   * Method to get the append a Subscriber's processed state.
+   */
+  public function setProcessedBy(string $class, bool $success) {
+    return $this->processedby[] = ['class' => $class, 'success' => $success];
+  }
+
+}

--- a/src/EventSubscriber/StrawberryfieldEventCompostBinSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventCompostBinSubscriber.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Drupal\strawberryfield\EventSubscriber;
+
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\strawberryfield\Event\StrawberryfieldFileEvent;
+use Drupal\strawberryfield\StrawberryfieldEventType;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for Composting Temp files event.
+ */
+class StrawberryfieldEventCompostBinSubscriber implements EventSubscriberInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Try to run last in case someone needs to do something with this file before
+   *
+   * @var int
+   */
+  protected static $priority = 700;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected MessengerInterface $messenger;
+
+  /**
+   * StrawberryfieldEventPresaveSubscriberAsFileStructureGenerator constructor.
+   *
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   */
+  public function __construct(
+    TranslationInterface $string_translation,
+    MessengerInterface $messenger
+  ) {
+    $this->stringTranslation = $string_translation;
+    $this->messenger = $messenger;
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+
+    $events[StrawberryfieldEventType::TEMP_FILE_CREATION][] = ['onTempFilePushed', static::$priority];
+    return $events;
+  }
+
+  /**
+   * Method called when Event occurs.
+   *
+   * @param \Drupal\strawberryfield\Event\StrawberryfieldFileEvent $event
+   *   The event.
+   */
+  public function onTempFilePushed(StrawberryfieldFileEvent $event) {
+    // Not much here to see. The Queue Worker does the logic
+    // We want to be quick as quick as we can.
+    $data = new \stdClass();
+    $data->uri = $event->getURI();
+    $data->module = $event->getModule();
+    $data->timestamp = $event->getTimeStamp();
+    if (!\Drupal::queue('sbf_compost_file', TRUE)
+      ->createItem($data)) {
+      $this->messenger->addError($this->t('We could not keep track of (enqueue) temporary file @file and will not be able to remove it later. Please check your logs and contact your admin to deal with it manually.', ['@file' => $data->uri]));
+    }
+    $current_class = get_called_class();
+    // Silly but i'm a destructor!
+    unset($data);
+    $event->setProcessedBy($current_class, TRUE);
+  }
+}

--- a/src/Plugin/QueueWorker/CompostQueueWorker.php
+++ b/src/Plugin/QueueWorker/CompostQueueWorker.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\QueueWorker;
+
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\File\Exception\FileException;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\Queue\RequeueException;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\strawberryfield\StrawberryfieldUtilityService;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+/**
+ * Deal with Temporary File cleanup/composting.
+ *
+ * @QueueWorker(
+ *   id = "sbf_compost_file",
+ *   title = @Translation("Archipelago Temporary File Composter Queue Worker")
+ * )
+ */
+class CompostQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManager definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The logger factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $loggerFactory;
+
+  /**
+   * The Strawberry Field Utility Service.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldUtilityService
+   */
+  protected $strawberryfieldUtility;
+
+  /**
+   * The messenger.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The StreamWrapper Manager
+   *
+   * @var \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface
+   */
+  protected StreamWrapperManagerInterface $streamWrapperManager;
+
+  /**
+   * The File System Service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected FileSystemInterface $fileSystem;
+
+  /**
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected ModuleHandlerInterface $moduleHandler;
+
+  /**
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  private ImmutableConfig $config;
+
+  /**
+   * Constructor.
+   *
+   * @param array                                                    $configuration
+   * @param string                                                   $plugin_id
+   * @param mixed                                                    $plugin_definition
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface           $entity_type_manager
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface        $logger_factory
+   * @param \Drupal\strawberryfield\StrawberryfieldUtilityService    $strawberryfield_utility_service
+   * @param \Drupal\Core\Messenger\MessengerInterface                $messenger
+   * @param \Drupal\Core\File\FileSystemInterface                    $file_system
+   * @param \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface            $module_handler
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    EntityTypeManagerInterface $entity_type_manager,
+    LoggerChannelFactoryInterface $logger_factory,
+    StrawberryfieldUtilityService $strawberryfield_utility_service,
+    MessengerInterface $messenger,
+    FileSystemInterface $file_system,
+    StreamWrapperManagerInterface $stream_wrapper_manager,
+    ModuleHandlerInterface $module_handler,
+    ConfigFactoryInterface $config_factory
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->loggerFactory = $logger_factory;
+    $this->strawberryfieldUtility = $strawberryfield_utility_service;
+    $this->messenger = $messenger;
+    $this->fileSystem = $file_system;
+    $this->streamWrapperManager = $stream_wrapper_manager;
+    $this->moduleHandler = $module_handler;
+    $this->config = $config_factory->get('strawberryfield.storage_settings');
+  }
+
+  /**
+   * Implementation of the container interface to allow dependency injection.
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   *
+   * @return static
+   */
+  public static function create(
+    ContainerInterface $container,
+    array $configuration,
+    $plugin_id,
+    $plugin_definition
+  ) {
+    return new static(
+      empty($configuration) ? [] : $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('logger.factory'),
+      $container->get('strawberryfield.utility'),
+      $container->get('messenger'),
+      $container->get('file_system'),
+      $container->get('stream_wrapper_manager'),
+      $container->get('module_handler'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data) {
+
+    /* $data will have the following structure
+     (object) array(
+        'uri' => 'private://webform/default_descriptive_metadata_ami/_sid_/cool file.jpg',
+        'module' => 'strawberryfield',
+        'timestamp' => 1652919451,
+    )
+*/
+    if (!function_exists('str_starts_with')) {
+      function str_starts_with($haystack, $needle) {
+        return (string) $needle !== ''
+          && strncmp(
+            $haystack, $needle, strlen($needle)
+          ) === 0;
+      }
+    }
+    if (!function_exists('str_ends_with')) {
+      function str_ends_with(string $haystack, string $needle): bool {
+        $needle_len = strlen($needle);
+        return ($needle_len === 0
+          || 0 === substr_compare(
+            $haystack, $needle, -$needle_len
+          ));
+      }
+    }
+    // Yes i know i'm being paranoid here!
+    $unsafe_prefix = ["."];
+    $unsafe_suffix = [".php", ".conf", ".yml", "settings"];
+
+    $safe_paths
+      = $safe_paths_default = [
+      'temporary://',
+      'private://webform/',
+      's3://webform/'
+    ];
+    $this->moduleHandler->alter(
+      'strawberryfield_compost_safe_basepaths',
+      $safe_paths
+    );
+    // Do not let a module delete all
+    if (empty($safe_paths)) {
+      $safe_paths = $safe_paths_default;
+    }
+
+    // First check if the file is there at all
+    if (!file_exists($data->uri)) {
+      // Nothing to check, nothing to do. Done.
+      return;
+    }
+    $safe = FALSE;
+    foreach ($safe_paths as $prefix) {
+      if (str_starts_with($data->uri, $prefix)) {
+        $safe = TRUE;
+        break;
+      }
+    }
+
+    $base_name = $this->fileSystem->basename($data->uri);
+
+    foreach ($unsafe_prefix as $prefix) {
+      if (str_starts_with($base_name, $prefix)) {
+        $safe = FALSE;
+        break;
+      }
+    }
+
+    foreach ($unsafe_suffix as $suffix) {
+      if (str_ends_with($base_name, $suffix)) {
+        $safe = FALSE;
+        break;
+      }
+    }
+
+    if (!$safe) {
+      // return silently. Safer...
+      return;
+    }
+    // Now check if the file is attached to an entity or not
+    /** @var \Drupal\file\FileInterface[] $files */
+    $files = $this->entityTypeManager
+      ->getStorage('file')
+      ->loadByProperties(['uri' => $data->uri]);
+    /** @var \Drupal\file\FileInterface|null $file */
+    $file = reset($files) ?: NULL;
+    if ($file) {
+      // return silently. Means some File entity took control over it
+      // Nothing we can do. Eventually someone will trigger the event
+      // Or Drupal will clean its mess.
+      return;
+    }
+    // Finall, now check the modification date: This is documented to work with
+    // S3:// too
+    $file_timestamp = filemtime($data->uri);
+
+    if (!$file_timestamp) {
+      // return silently. Means we can not stat the file. Means we won't be able
+      // to delete it.
+      return;
+    }
+
+    $composting_time = ($file_timestamp + (int) ($this->config->get(
+          'compost_maximum_age'
+        ) ?? 21600) <= (new DrupalDateTime())->getTimestamp());
+
+    if ($composting_time) {
+      // Deal with possibly some Drupal 8 until release 1.1.0
+      try {
+        // This will log errors but we do not want to throw and exception
+        // So we will get it
+        // ::unlink() will be silent but we do want to keep logs around i guess?
+        $uri = $data->uri ?? NULL;
+        if ($uri) {
+          $this->fileSystem->delete($uri);
+        }
+      }
+      catch (FileException $exception) {
+        // Fail silently. We won't be able to delete it anyways.
+        return;
+      }
+    }
+    else {
+      if (class_exists('\Drupal\Core\Queue\DelayedRequeueException')) {
+        throw new \Drupal\Core\Queue\DelayedRequeueException(
+          0, 'Not yet the time to compost'
+        );
+      }
+      else {
+        // Drupal 8 Compat. This might make the queue run over this until
+        // Lease time expires. Not optimal.
+        throw new RequeueException(
+          'Not yet the time to compost'
+        );
+      }
+    }
+  }
+}

--- a/src/StrawberryfieldEventType.php
+++ b/src/StrawberryfieldEventType.php
@@ -184,4 +184,18 @@ final class StrawberryfieldEventType {
    */
   const DELETE_FLAVOUR = 'sbf.flavour.delete';
 
+
+  /**
+   * Name of the event fired when generating a temp file.
+   *
+   * This event allows modules to perform an action on Temp file creation
+   * A default Subscriber will enqueue these for removal
+   *
+   * @Event
+   *
+   * @see \Drupal\strawberryfield\Event\StrawberryfieldFileEvent
+   *
+   * @var string
+   */
+  const TEMP_FILE_CREATION = 'sbf.file.tmp';
 }

--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -324,7 +324,7 @@ class StrawberryfieldJsonHelper {
 
 
   /**
-   * Array helper that checks if an array is associative or not
+   * Array helper that checks if an array is associative or not.
    *
    * @param array $sourcearray
    *
@@ -333,6 +333,27 @@ class StrawberryfieldJsonHelper {
    */
   public static function arrayIsMultiSimple(array $sourcearray =  []) {
       return !empty(array_filter(array_keys($sourcearray), 'is_string'));
+  }
+
+  /**
+   * Array helper that checks if an array is associative with URN/URI keys.
+   *
+   *
+   * @param array $sourcearray
+   *
+   * @return bool
+   *  TRUE if is associative and each key is an URI. Useful for detecging Object
+   *  JSON type of Arrays with no repeating patterns like we use for
+   *  as:images, etc
+   */
+  public static function arrayIsMultiURIkeys(array $sourcearray = []) {
+    $keys = array_keys($sourcearray);
+    $keys_URIS = array_filter($keys, function ($value) {
+      if (filter_var($value, FILTER_VALIDATE_URL) || static::validateURN($value)) {
+        return TRUE;
+      }
+    });
+    return (count($keys) > 0 && (count($keys) == count($keys_URIS)));
   }
 
   /**

--- a/strawberryfield.api.php
+++ b/strawberryfield.api.php
@@ -66,5 +66,16 @@ function hook_strawberryfield_file_destination_alter(array &$processed_file_part
 }
 
 /**
+ * Lets modules alter the which Paths as considered safe for Composting removal
+ *
+ * @param array $base_uris
+ *    An array with fully qualified basepaths with a streamwrapper prefix.
+ */
+function hook_strawberryfield_compost_safe_basepaths_alter(array &$base_uris) {
+  // Example alter
+  $base_uris[] = 'private://webform/';
+}
+
+/**
  * @} End of "addtogroup hooks".
  */

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -9,7 +9,7 @@ services:
       - { name: backend_overridable }
   strawberryfield.file_persister:
     class: Drupal\strawberryfield\StrawberryfieldFilePersisterService
-    arguments: [ '@file_system', '@file.usage', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@config.factory', '@current_user', '@language_manager', '@transliteration', '@module_handler', '@logger.factory', '@strawberryfield.utility', '@strawberryfield.file_metadata_extractor']
+    arguments: [ '@file_system', '@file.usage', '@entity_type.manager', '@stream_wrapper_manager', '@plugin.manager.archiver', '@config.factory', '@current_user', '@language_manager', '@transliteration', '@module_handler', '@logger.factory', '@strawberryfield.utility', '@strawberryfield.file_metadata_extractor', '@event_dispatcher']
     tags:
       - { name: backend_overridable }
   strawberryfield.keyname_manager:
@@ -80,6 +80,11 @@ services:
     tags:
       - { name: event_subscriber }
     arguments: ['@strawberryfield.utility']
+  strawberryfield.compost_bin_subscriber:
+    class: Drupal\strawberryfield\EventSubscriber\StrawberryfieldEventCompostBinSubscriber
+    tags:
+      - { name: event_subscriber }
+    arguments: ['@string_translation', '@messenger']
   strawberryfield.paramconverter.entity:
     class: Drupal\strawberryfield\ParamConverter\UuidEntityConverter
     tags:


### PR DESCRIPTION
See #222 

This pull adds:

- New EventType and Event Subscriber. Event is triggered during and ADO's file persistence and when we are sure it happened. The Subscriber fills a queue.
- The queue worker checks if the file is there, if its safe, if its not used by an Entity, if it has been longer or === than the max time to live and deletes it. If all matches, except time it re-enqueues (Double check Hydroponics since we are using a new D9 Class here)
- There is also a hook that allows other modules to inform where/what is safe.
- There is also a new Config to be seen at `/admin/config/archipelago/filepersisting`
![image](https://user-images.githubusercontent.com/6946023/169378355-d97fc4e9-2ce1-46e3-a2fe-dd0a84b5c896.png)

The queue needs to be configured to Run hopefully using Hydroponics but testing can be also done via the System Queue manager.

Other modules (e.g SB Flavors) will invoke the event too to mark its own temps are "compostable"♻️ 


@patdunlavey @alliomeria @aksm @giancarlobi If any of you see anything strange in the code let me know?




 