### PR TITLE
ISSUE-225: Add str_flatten_keys_unfiltered and filter out empties on str_flatten…

### DIFF
--- a/src/Plugin/DataType/StrawberryKeysFromJson.php
+++ b/src/Plugin/DataType/StrawberryKeysFromJson.php
@@ -65,16 +65,26 @@ class StrawberryKeysFromJson extends ItemList {
     }
     $values = [];
     $item = $this->getParent();
+    $definition = $this->getDataDefinition();
+    // This key is passed by the property definition in the field class
+    // jsonkey in this context is a string containing one or more
+    // jmespath's separated by comma.
+    $filter_empties = $definition['settings']['filter_empties'] ?? FALSE;
     if (!empty($item->value)) {
       // Should 10 be enough? this is json-ld not github.. so maybe...
       $jsonArray = json_decode($item->value, TRUE, 50);
       //@TODO deal with JSON exceptions as we have done before
 
       $flattened = [];
-      $blacklist = ['ap:importeddata.content'];
+      $exclude = ['ap:importeddata.content'];
       $flattened = StrawberryfieldJsonHelper::arrayToFlatJsonPropertypaths(
-        $jsonArray, '', $blacklist
+        $jsonArray, '', $exclude
       );
+      if ($filter_empties) {
+        $flattened = array_filter($flattened, function($value) {
+          return ($value !== null && $value !== '' && $value !== []);
+        });
+      }
       $this->processed = array_keys($flattened);
       $this->computed = TRUE;
       foreach ($this->processed as $delta => $item) {

--- a/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
@@ -110,15 +110,25 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
                 }
                 break;
               default:
-                $values_parsed[] = date('c', $edtf_value->getMin());
-                $values_parsed[] = date('c', $edtf_value->getMax());
+                // Make sure we do not index same day twice
+                $start_day = date('Y-m-d', $edtf_value->getMin());
+                $end_day = date('Y-m-d', $edtf_value->getMax());
+                if ($start_day === $end_day) {
+                  // if this is the same day just index one.
+                  $values_parsed[] = date('c', $edtf_value->getMin());
+                }
+                else {
+                  $values_parsed[] = date('c', $edtf_value->getMin());
+                  $values_parsed[] = date('c', $edtf_value->getMax());
+                }
                 break;
             }
           }
           else {
             // If not EDTF (e.g an already ISO8601 date)
             // try with string based parsing
-            $values_parsed[] = $this->parseStringToDate($value);
+            $parsed_from_string = $this->parseStringToDate($value);
+            $values_parsed[] = $parsed_from_string ? $parsed_from_string: NULL;
           }
         }
         $values = array_unique($values_parsed);

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -88,6 +88,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
      $reserved_keys = [
        'value',
        'str_flatten_keys',
+       'str_flatten_keys_unfiltered',
      ];
 
      // @TODO mapDataDefinition() is the next step.
@@ -106,6 +107,19 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
          '\Drupal\strawberryfield\Plugin\DataType\StrawberryKeysFromJson'
        )
        ->setInternal(FALSE)
+       ->setSetting('filter_empties', TRUE)
+       ->setReadOnly(TRUE);
+
+     // All properties as Property keys.
+     // Handy when dealing with Field formatters
+     $properties['str_flatten_keys_unfiltered'] = ListDataDefinition::create('string')
+       ->setLabel('JSON keys defined in this field')
+       ->setComputed(TRUE)
+       ->setClass(
+         '\Drupal\strawberryfield\Plugin\DataType\StrawberryKeysFromJson'
+       )
+       ->setInternal(TRUE)
+       ->setSetting('filter_empties', FALSE)
        ->setReadOnly(TRUE);
 
      $keynamelist = [];

--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -233,7 +233,7 @@ class StrawberryfieldJsonHelper {
    * @param string $propertypath;
    *   Use to accumulate the propertypath between recursive calls.
    * @param array $excludepaths;
-   *   Use to pass a list of blacklisted paths
+   *   Use to pass a list of paths to exclude
    *
    * @return array
    */


### PR DESCRIPTION
See #225 

- This adds a data definition property `->setSetting('filter_empties', (boolean))` and a new Field Property named `str_flatten_keys_unfiltered` that preserves the previous behavior of indexing every JSON Path present in and ADO. 
- Some minor language changes happened too
- Also: deduplicates dates (EDTF) where start/end happen on the same day since there is not way of knowing upfront if uncertainties will add a range to an existing single date string (tested, works)
- Fixes a small bug where Solr backend can not deal with dates === FALSE (what the parser gives for non EDTF when the date is wrong) and needs a NULL instead (this was fixed in production on DCMNY)