### PR TITLE
ISSUE-257: Humble (and experimental) attempt at dealing with stale/missing excerpts

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -313,3 +313,6 @@ plugin.plugin_configuration.search_api_processor.sbf_highlight:
     highlight_partial:
       type: boolean
       label: 'Whether matches in parts of words should be highlighted'
+    lazy_excerpt:
+      type: boolean
+      label: 'Whether the lazy loading workaround is enabled to deliver fresh(er) Excerpts on GET requests'

--- a/src/StrawberryfieldLazyBuilders.php
+++ b/src/StrawberryfieldLazyBuilders.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\strawberryfield;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Security\TrustedCallbackInterface;
+use Drupal\Core\Render\RendererInterface;
+
+/**
+ * Defines a service for #lazy_builder callbacks for strawberryfield module.
+ */
+class StrawberryfieldLazyBuilders implements TrustedCallbackInterface {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The renderer service.
+   *
+   * @var \Drupal\Core\Render\RendererInterface
+   */
+  protected $renderer;
+
+  protected $_excerpts = NULL;
+
+  /**
+   * Constructs a new CommentLazyBuilders object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\Render\RendererInterface $renderer
+   *   The renderer service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, RendererInterface $renderer) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->renderer = $renderer;
+  }
+
+
+  public function setExcerpt($cid, $excerpt) {
+    $this->_excerpts[$cid] = $excerpt;
+  }
+
+  public function getExcerpt($cid) {
+    return $this->_excerpts[$cid] ?? NULL;
+  }
+
+
+  /**
+   * #lazy_builder callback; builds the comment form.
+   *
+   * @param string $cid
+   *   The Item result ID from Search API results..
+   * @param string $extra_tag
+   *   Additional cache tag
+   *
+   * @return array
+   *   A renderable array containing excerpt.
+   */
+  public function renderExcerpt(string $cid, string $extra_tag) {
+
+    if ($excerpt = ($this->_excerpts[$cid] ?? NULL)) {
+      //@TODO add node:node_id as tag? Could be passed as an argument
+      return [
+        '#type' => 'markup',
+        '#markup' => $this->_excerpts[$cid],
+        '#cache' => [
+          'contexts' => ['url.query_args','user.node_grants:view'],
+          'tags' => ['search_api_index_list',$extra_tag],
+        ]
+      ];
+    }
+    return [];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function trustedCallbacks() {
+    return ['renderExcerpt'];
+  }
+
+}

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -23,6 +23,9 @@ use Drupal\Core\Field\FieldDefinitionInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Field\FieldItemListInterface;
 use Solarium\Core\Query\QueryInterface as SolariumQueryInterface;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_ENTITY_TYPE_presave().
@@ -379,5 +382,33 @@ function strawberryfield_cron() {
   // Is invoked but never with `drush cron`
   if (PHP_SAPI != 'cli') {
     \Drupal::getContainer()->get('strawberryfield.hydroponics')->run();
+  }
+}
+
+/**
+ * Implements hook_entity_view_alter().
+ */
+function strawberryfield_entity_view_alter(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  $excerpt_component = $display->getComponent('search_api_excerpt');
+  if ($excerpt_component !== NULL && $entity instanceof NodeInterface && $entity->view ?? NULL) {
+    if (\Drupal::request()->getMethod() == 'GET' ) {
+      // Check if the current index has lazy_excerpt enabled...
+      if ($processor = ($entity->view->getQuery()->getIndex()->getProcessors(
+        )['sbf_highlight'] ?? NULL)
+      ) {
+        if ($processor->getConfiguration()['lazy_excerpt']) {
+          $cid = 'entity:' . $entity->getEntityTypeId() . '/' . $entity->id()
+            . ':'
+            . $entity->language()->getId();
+          $build['search_api_excerpt'] = [
+            '#lazy_builder'       => [
+              'strawberryfield.lazy_builders:renderExcerpt',
+              [$cid, 'node:'.$entity->id()]
+            ],
+            '#create_placeholder' => TRUE,
+          ];
+        }
+      }
+    }
   }
 }

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -107,3 +107,6 @@ services:
     arguments: ['@entity_type.manager', '@current_user', '@strawberryfield.utility', '@config.factory']
     tags:
       - { name: breadcrumb_builder, priority: 1500 }
+  strawberryfield.lazy_builders:
+    class: Drupal\strawberryfield\StrawberryfieldLazyBuilders
+    arguments: [ '@entity_type.manager', '@renderer' ]


### PR DESCRIPTION
See #257 

... on GET calls.
This enables a new config option for our advanced highlighter and enables a very experimental lazy loading mechanism when needed, allowing still POST calls to get around the fact that they are "barely" cached... (except at the Views level, but we don't mess with that right? :( Also this whole day could have been a cache time set to 0 .... but i like people...

To be honest, I feel this is over engineered... I understand the use case and the need and I might develop this better/further soon. I don't know if even caching this beyond time to live 0 is more performant or not