### PR TITLE
ISSUE-265: Allow a workaround for dot files when composting

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -97,6 +97,10 @@ strawberryfield.storage_settings:
       type: integer
       label: 'Max time to live of Archipelago generated Temporary Files'
       default: 21600
+    compost_dot_files:
+      type: boolean
+      label: 'If dot files are safe to be composted/deleted if found inside a safe Path'
+      default: false
 
 strawberryfield.archipelago_solr_settings:
   type: config_object

--- a/src/Form/FilePersisterServiceSettingsForm.php
+++ b/src/Form/FilePersisterServiceSettingsForm.php
@@ -146,7 +146,6 @@ class FilePersisterServiceSettingsForm extends ConfigFormBase {
       '#type' => 'checkbox',
       '#title' => $this->t('During Compost, treat dot files as safe to be deleted, if inside a safe Path.'),
       '#default_value' => $config_storage->get('compost_dot_files') ?? FALSE,
-      '#options' => $period,
       '#description' => $this->t('When enabled, we will ease the security concern for hidden files, if and only if the file to be composted is in a safe path. e.g /tmp. Safe paths by default are private://webform, temporary:// and /tmp'),
     ];
 

--- a/src/Form/FilePersisterServiceSettingsForm.php
+++ b/src/Form/FilePersisterServiceSettingsForm.php
@@ -147,7 +147,7 @@ class FilePersisterServiceSettingsForm extends ConfigFormBase {
       '#title' => $this->t('During Compost, treat dot files as safe to be deleted, if inside a safe Path.'),
       '#default_value' => $config_storage->get('compost_dot_files') ?? FALSE,
       '#options' => $period,
-      '#description' => $this->t('When enabled, we will ease the security concern for hidden files, if and only if the file to be composted is in a safe path. e.g /tmp. Safe paths by default are private://webform; temporary://, /tmp'),
+      '#description' => $this->t('When enabled, we will ease the security concern for hidden files, if and only if the file to be composted is in a safe path. e.g /tmp. Safe paths by default are private://webform, temporary:// and /tmp'),
     ];
 
     $form['extractmetadata'] = [

--- a/src/Form/FilePersisterServiceSettingsForm.php
+++ b/src/Form/FilePersisterServiceSettingsForm.php
@@ -142,6 +142,13 @@ class FilePersisterServiceSettingsForm extends ConfigFormBase {
       '#options' => $period,
       '#description' => $this->t('Temporary Files are left overs of Archipelago processing and associated modules. They are safe to be removed. <strong>NOTE:</strong> Cleanup frequency (check/delete) is different to this setting. Temporary Files might fill up your filesystem. Make sure the "Archipelago Temporary File Composter Queue Worker" queue is programmed to run frequently.'),
     ];
+    $form['compost_dot_files'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('During Compost, treat dot files as safe to be deleted, if inside a safe Path.'),
+      '#default_value' => $config_storage->get('compost_dot_files') ?? FALSE,
+      '#options' => $period,
+      '#description' => $this->t('When enabled, we will ease the security concern for hidden files, if and only if the file to be composted is in a safe path. e.g /tmp. Safe paths by default are private://webform; temporary://, /tmp'),
+    ];
 
     $form['extractmetadata'] = [
       '#type' => 'checkbox',
@@ -592,6 +599,7 @@ class FilePersisterServiceSettingsForm extends ConfigFormBase {
       ->set('object_file_strategy', $form_state->getValue('object_file_strategy'))
       ->set('object_file_path', trim($form_state->getValue('object_file_path')," \n\r\t\v\0/"))
       ->set('compost_maximum_age', (int) $form_state->getValue('compost_maximum_age'))
+      ->set('compost_dot_files', (bool) $form_state->getValue('compost_dot_files'))
       ->save();
     parent::submitForm($form, $form_state);
   }

--- a/src/Plugin/QueueWorker/CompostQueueWorker.php
+++ b/src/Plugin/QueueWorker/CompostQueueWorker.php
@@ -216,10 +216,15 @@ class CompostQueueWorker extends QueueWorkerBase implements ContainerFactoryPlug
     }
 
     $base_name = $this->fileSystem->basename($data->uri);
-    foreach ($unsafe_prefix as $prefix) {
-      if (str_starts_with($base_name, $prefix)) {
-        $safe = FALSE;
-        break;
+    // Bypass prefix check if enabled and in a safe place already
+    $bypass_dot = ($this->config->get('compost_dot_files') && $safe);
+
+    if (!$bypass_dot) {
+      foreach ($unsafe_prefix as $prefix) {
+        if (str_starts_with($base_name, $prefix)) {
+          $safe = FALSE;
+          break;
+        }
       }
     }
 
@@ -230,9 +235,29 @@ class CompostQueueWorker extends QueueWorkerBase implements ContainerFactoryPlug
       }
     }
 
+    // still never ever allow .htaccess or .env to be deleted.
+    // paranoid android-Diego.
+    if (in_array($base_name, ['.htaccess', '.env'])) {
+      $safe = FALSE;
+    }
+
+
     if (!$safe) {
-      // return silently. Safer...
-      return;
+      $this->loggerFactory->get('archipelago')->warning('Attempt to compost an unsafe File with path <em>@path</em> was made. Please manually delete it or lower/configure your security settings and code overrides defining what a Safe Path is.',[
+        '@path' => $data->uri
+      ]);
+      if (class_exists('\Drupal\Core\Queue\DelayedRequeueException')) {
+        throw new \Drupal\Core\Queue\DelayedRequeueException(
+          0, 'Unsafe File found. Check your logs and deal with it. We will still try again later.'
+        );
+      }
+      else {
+        // Drupal 8 Compat. This might make the queue run over this until
+        // Lease time expires. Not optimal.
+        throw new RequeueException(
+          'Unsafe File found. Check your logs and deal with it. We will still try again later.'
+        );
+      }
     }
     // Now check if the file is attached to an entity or not
     /** @var \Drupal\file\FileInterface[] $files */


### PR DESCRIPTION
see #265 

This will also always re-enqueue unsafe files and log them. This will at least allow us to show the user these exist and allow an informed decision to be made. @alliomeria @aksm those this sound ok?

Could I get a sanitizing look from you both?