### PR TITLE
ISSUE-276: Upgrade EDTF PHP library from 2.0.2 to 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "frictionlessdata/datapackage": "dev-main",
         "drupal/search_api": "~1.29",
         "drupal/search_api_solr": "^4.2.10",
-        "professional-wiki/edtf": "~2.0",
+        "professional-wiki/edtf": "~3.0",
         "mhor/php-mediainfo": "~5.4"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Resolves #276.

Tested with various date intervals in facets via JmesPath Strawberry Field Key Name Provider, with the edtf_2_human_date Twig extension, and with the webforms.