### PR TITLE
ISSUE-286: Break the 5 Gbytes barrier without breaking the bank

### DIFF
--- a/config/schema/strawberryfield.schema.yml
+++ b/config/schema/strawberryfield.schema.yml
@@ -79,6 +79,10 @@ strawberryfield.storage_settings:
     file_scheme:
       type: string
       label: 'Storage Scheme for Persisting Files'
+    multipart_upload_threshold:
+      type: integer
+      label: 'At what file size (in bytes) Multipart copy/put should be used when the destination of a file is S3'
+      default: 5368709120
     file_path:
       type: string
       label: 'Storage Path under the Storage Scheme, for Persisting Files'

--- a/src/Form/FilePersisterServiceSettingsForm.php
+++ b/src/Form/FilePersisterServiceSettingsForm.php
@@ -84,10 +84,10 @@ class FilePersisterServiceSettingsForm extends ConfigFormBase {
     $form['multipart_upload_threshold'] = [
       '#type' => 'number',
       '#title' => $this->t('Specify file size (in bytes) when Multipart Upload/Copy should be attempted.'),
-      '#description' => $this->t('Only applies when the Storage Scheme used is S3 driven (e.g s3://). The default is 5Gbytes. The lowest number possible is 100 Mbytes'),
+      '#description' => $this->t('Only applies when the Storage Scheme used is S3 driven (e.g s3://). The default is 5Gbytes. The lowest threshold possible is 100 Mbytes'),
       '#default_value' => $config_storage->get('multipart_upload_threshold') ?? 5368709120,
-      '#min' => 102400,
-      '#step' => 1024,
+      '#min' => 104857600,
+      '#step' => 1048576,
       '#max' => 5368709120,
       '#required' => TRUE
     ];

--- a/src/Form/FilePersisterServiceSettingsForm.php
+++ b/src/Form/FilePersisterServiceSettingsForm.php
@@ -81,6 +81,16 @@ class FilePersisterServiceSettingsForm extends ConfigFormBase {
       '#options' => $scheme_options,
       '#required' => TRUE
     ];
+    $form['multipart_upload_threshold'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Specify file size (in bytes) when Multipart Upload/Copy should be attempted.'),
+      '#description' => $this->t('Only applies when the Storage Scheme used is S3 driven (e.g s3://). The default is 5Gbytes. The lowest number possible is 100 Mbytes'),
+      '#default_value' => $config_storage->get('multipart_upload_threshold') ?? 5368709120,
+      '#min' => 102400,
+      '#step' => 1024,
+      '#max' => 5368709120,
+      '#required' => TRUE
+    ];
     $form['file_path'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Relative Path for Persisting Files'),
@@ -593,6 +603,7 @@ class FilePersisterServiceSettingsForm extends ConfigFormBase {
       ->save();
     $this->config('strawberryfield.storage_settings')
       ->set('file_scheme', $form_state->getValue('file_scheme'))
+      ->set('multipart_upload_threshold', (int) $form_state->getValue('multipart_upload_threshold'))
       ->set('file_path', trim($form_state->getValue('file_path')," \n\r\t\v\0/"))
       ->set('object_file_scheme', $form_state->getValue('object_file_scheme'))
       ->set('object_file_strategy', $form_state->getValue('object_file_strategy'))

--- a/src/Plugin/QueueWorker/CompostQueueWorker.php
+++ b/src/Plugin/QueueWorker/CompostQueueWorker.php
@@ -243,21 +243,10 @@ class CompostQueueWorker extends QueueWorkerBase implements ContainerFactoryPlug
 
 
     if (!$safe) {
-      $this->loggerFactory->get('archipelago')->warning('Attempt to compost an unsafe File with path <em>@path</em> was made. Please manually delete it or lower/configure your security settings and code overrides defining what a Safe Path is.',[
+      $this->loggerFactory->get('archipelago')->warning('Attempt to compost an unsafe File with path <em>@path</em> was made. If you need to remove it, please do it so manually. If not, you can ignore this warning.',[
         '@path' => $data->uri
       ]);
-      if (class_exists('\Drupal\Core\Queue\DelayedRequeueException')) {
-        throw new \Drupal\Core\Queue\DelayedRequeueException(
-          0, 'Unsafe File found. Check your logs and deal with it. We will still try again later.'
-        );
-      }
-      else {
-        // Drupal 8 Compat. This might make the queue run over this until
-        // Lease time expires. Not optimal.
-        throw new RequeueException(
-          'Unsafe File found. Check your logs and deal with it. We will still try again later.'
-        );
-      }
+      return;
     }
     // Now check if the file is attached to an entity or not
     /** @var \Drupal\file\FileInterface[] $files */

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -814,7 +814,7 @@ class StrawberryfieldFilePersisterService {
                       $destination_uri = $this->copyOrPutS3Aware($current_uri, $destination_uri);
                     }
                     else {
-                      // Nomral Copy to new destination
+                      // Normal Copy to new destination
                       $destination_uri = $this->fileSystem->copy(
                         $current_uri,
                         $destination_uri
@@ -1469,7 +1469,6 @@ class StrawberryfieldFilePersisterService {
             return FALSE;
           }
         }
-
       }
       catch (\Exception $exception) {
         $this->loggerFactory->get('strawberryfield')->error('File upload %source_uri failed because we could not connect to S3.', [


### PR DESCRIPTION
See #286 

This adds a new config form element:

![image](https://github.com/esmero/strawberryfield/assets/6946023/d54d5abf-bdc9-4218-b664-dcea94510089)

And enforces that setting (5 Gbytes by default, the exact default we need) to attempt either a `MultiPart` Upload Operation (with a multipart retry) or a `MultiPart` Copy Operation (between S3 URIs) to manage very large files (basically anything larger to 5 Gbytes if you don't change the default settings.)

Tested and re-retested but might YET again test tomorrow before merging.