### PR TITLE
ISSUE-303: Escape Tags on RAW JSON formatter

### DIFF
--- a/src/Plugin/Field/FieldFormatter/StrawberryDefaultFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/StrawberryDefaultFormatter.php
@@ -90,7 +90,7 @@ class StrawberryDefaultFormatter extends FormatterBase {
           'json' => [
             '#markup' => json_encode(
               json_decode($item->value, TRUE),
-              JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE
+              JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE |JSON_HEX_TAG
             ),
             '#prefix' => '<pre>',
             '#suffix' => '</pre>',


### PR DESCRIPTION
# What?

See #303 

Helps fixing issues that kick you (bite and never let you go) when people add  to their JSON HTML tags inside values (and unclosed ones) and the RAW output ends breaking the JS (that is loaded HTML wise after the whole body ..)

Simple little one / smallish fix