### PR TITLE
ISSUE-320: Adds a new Key value DB class with ranged/listed queries

### DIFF
--- a/src/KeyValueStore/DatabaseStorageWithIndex.php
+++ b/src/KeyValueStore/DatabaseStorageWithIndex.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Drupal\strawberryfield\KeyValueStore;
+
+use Drupal\Component\Serialization\SerializationInterface;
+use Drupal\Core\Database\Query\Merge;
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Database\DatabaseException;
+use Drupal\Core\KeyValueStore\DatabaseStorage;
+use Drupal\Core\DependencyInjection\DependencySerializationTrait;
+
+/**
+ * Defines a default key/value store implementation.
+ *
+ * This is Drupal's default key/value store implementation. It uses the database
+ * to store key/value data.
+ */
+class DatabaseStorageWithIndex extends DatabaseStorage {
+
+  use DependencySerializationTrait;
+
+  /**
+   * The serialization class to use.
+   *
+   * @var \Drupal\Component\Serialization\SerializationInterface
+   */
+  protected $serializer;
+
+  /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * The name of the SQL table to use.
+   *
+   * @var string
+   */
+  protected $table;
+
+
+  public function listKeys(int $offset = 0, int $count = 100) {
+      try {
+        $result = $this->connection->queryRange('SELECT [name] FROM {' . $this->connection->escapeTable($this->table) . '} WHERE [collection] = :collection ORDER BY [name] ASC', $offset, $count, [
+          ':collection' => $this->collection
+        ]);
+      }
+      catch (\Exception $e) {
+        $this->catchException($e);
+        $result = [];
+      }
+      $values = [];
+      foreach ($result as $item) {
+        if ($item) {
+          $values[$item->name] = $values[$item->name];
+        }
+      }
+      return $values;
+  }
+
+  public function getMultipleListed(int $offset = 0, int $count = 100) {
+    try {
+      $result = $this->connection->queryRange('SELECT [name] [value] FROM {' . $this->connection->escapeTable($this->table) . '} WHERE [collection] = :collection ORDER BY [name] ASC', $offset, $count, [
+        ':collection' => $this->collection,
+      ]);
+    }
+    catch (\Exception $e) {
+      $this->catchException($e);
+      $result = [];
+    }
+    $values = [];
+    foreach ($result as $item) {
+      if ($item) {
+        $values[$item->name] = $this->serializer->decode($item->value);
+      }
+    }
+    return $values;
+  }
+
+}

--- a/src/KeyValueStore/KeyValueDatabaseWithIndexFactory.php
+++ b/src/KeyValueStore/KeyValueDatabaseWithIndexFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drupal\strawberryfield\KeyValueStore;
+
+use Drupal\Component\Serialization\SerializationInterface;
+
+use Drupal\Core\Database\Connection;
+
+use Drupal\strawberryfield\KeyValueStore\DatabaseStorageWithIndex;
+
+use Drupal\Core\KeyValueStore\KeyValueFactoryInterface;
+
+
+/**
+ * Defines the key/value store factory for the database backend.
+ */
+class KeyValueDatabaseWithIndexFactory implements KeyValueFactoryInterface {
+
+  /**
+   * The serialization class to use.
+   *
+   * @var \Drupal\Component\Serialization\SerializationInterface
+   */
+  protected $serializer;
+
+  /**
+   * The database connection to use.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
+   * Constructs this factory object.
+   *
+   * @param \Drupal\Component\Serialization\SerializationInterface $serializer
+   *   The serialization class to use.
+   * @param \Drupal\Core\Database\Connection $connection
+   *   The Connection object containing the key-value tables.
+   */
+  public function __construct(SerializationInterface $serializer, Connection $connection) {
+    $this->serializer = $serializer;
+    $this->connection = $connection;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function get($collection) {
+    return new DatabaseStorageWithIndex($collection, $this->serializer, $this->connection);
+  }
+
+}

--- a/strawberryfield.services.yml
+++ b/strawberryfield.services.yml
@@ -127,3 +127,6 @@ services:
     class: \Drupal\strawberryfield\StrawberryfieldSearchAPIUtilityService
     tags:
       - { name: backend_overridable }
+  strawberryfield.keyvalue.database:
+    class: Drupal\strawberryfield\KeyValueStore\KeyValueDatabaseWithIndexFactory
+    arguments: [ '@serialization.phpserialize', '@database' ]


### PR DESCRIPTION
See #320 

This implements for key/value tables a "wrapper class" that allows listings of existing key values to be made (including get whole/list just the keys) without knowing the actual key name

This is needed to allow our datasource to be re-tracked.

The re-tracker is implemented using the existing interface at ::getPartialItemIds but it does something (i hope) well. It checks if the Nodes/Files associated with a stored SBF Flavor data source entry, still exist. and tries to fill/refill data if a query returns many but none of these are valid... I need to check more because i added a WHILE statement... dangerous stuff. So far so good with my limited to 1500 OCRs test.

@alliomeria @roromedia ping (pong) and ping again