### PR TITLE
ISSUE-325: Vectors for each king, one float to rule them all

### DIFF
--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_1024_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_1024_und_9_0_0.yml
@@ -8,7 +8,6 @@ dependencies:
 id: dense_vector_field_1024_und
 label: 'Dense Vector Field of 1024 dimensions suitable for mobileNetV3 feature extraction (embeddings) using dot_product as comparison algorithm'
 minimum_solr_version: 9.0.0
-custom_code: knn_1024
 field_type_language_code: und
 domains: {  }
 field_type:

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_1024_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_1024_und_9_0_0.yml
@@ -1,0 +1,22 @@
+uuid: 05342da1-9340-4e4b-8697-0bbdfc8d80fe
+langcode: en
+status: true
+dependencies:
+  module:
+    - strawberryfield
+    - search_api_solr
+id: dense_vector_field_1024_und
+label: 'Dense Vector Field of 1024 dimensions suitable for mobileNetV3 feature extraction (embeddings) using dot_product as comparison algorithm'
+minimum_solr_version: 9.0.0
+custom_code: knn_1024
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: knn_vector_1024
+  class: solr.DenseVectorField
+  vectorDimension: 1024
+  similarityFunction: dot_product
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+text_files: {  }

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_384_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_384_und_9_0_0.yml
@@ -8,7 +8,6 @@ dependencies:
 id: dense_vector_field_384_und
 label: 'Dense Vector Field of 384 dimensions suitable for Bert text feature extraction (embeddings) using dot_product as comparison algorithm'
 minimum_solr_version: 9.0.0
-custom_code: knn_384
 field_type_language_code: und
 domains: {  }
 field_type:

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_384_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_384_und_9_0_0.yml
@@ -1,0 +1,22 @@
+uuid: 3ac7a111-8af9-40d8-9d41-5edfa8e3971a
+langcode: en
+status: true
+dependencies:
+  module:
+    - strawberryfield
+    - search_api_solr
+id: dense_vector_field_384_und
+label: 'Dense Vector Field of 384 dimensions suitable for Bert text feature extraction (embeddings) using dot_product as comparison algorithm'
+minimum_solr_version: 9.0.0
+custom_code: knn_384
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: knn_vector_384
+  class: solr.DenseVectorField
+  vectorDimension: 384
+  similarityFunction: dot_product
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+text_files: {  }

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_512_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_512_und_9_0_0.yml
@@ -8,7 +8,6 @@ dependencies:
 id: dense_vector_field_512_und
 label: 'Dense Vector Field of 512 dimensions suitable for Apple Vision ML Image FingerPrint (embeddings) using dot_product as comparison algorithm'
 minimum_solr_version: 9.0.0
-custom_code: knn_512
 field_type_language_code: und
 domains: {  }
 field_type:

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_512_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_512_und_9_0_0.yml
@@ -1,0 +1,22 @@
+uuid: eaf9db6d-bf73-4800-9e61-19a0b084c9bc
+langcode: en
+status: true
+dependencies:
+  module:
+    - strawberryfield
+    - search_api_solr
+id: dense_vector_field_512_und
+label: 'Dense Vector Field of 512 dimensions suitable for Apple Vision ML Image FingerPrint (embeddings) using dot_product as comparison algorithm'
+minimum_solr_version: 9.0.0
+custom_code: knn_512
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: knn_vector_512
+  class: solr.DenseVectorField
+  vectorDimension: 512
+  similarityFunction: dot_product
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+text_files: {  }

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_576_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_576_und_9_0_0.yml
@@ -1,0 +1,22 @@
+uuid: 38af5bbc-99de-43cb-9916-a70be8f1f9da
+langcode: en
+status: true
+dependencies:
+  module:
+    - strawberryfield
+    - search_api_solr
+id: dense_vector_field_576_und
+label: 'Dense Vector Field of 576 dimensions suitable for YOLOv8 feature extraction using dot_product as comparison algorithm'
+minimum_solr_version: 9.0.0
+custom_code: knn_576
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: knn_vector_576
+  class: solr.DenseVectorField
+  vectorDimension: 576
+  similarityFunction: dot_product
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+text_files: {  }

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_576_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_576_und_9_0_0.yml
@@ -8,7 +8,6 @@ dependencies:
 id: dense_vector_field_576_und
 label: 'Dense Vector Field of 576 dimensions suitable for YOLOv8 feature extraction using dot_product as comparison algorithm'
 minimum_solr_version: 9.0.0
-custom_code: knn_576
 field_type_language_code: und
 domains: {  }
 field_type:

--- a/src/EventSubscriber/SearchApiSolrEventSubscriber.php
+++ b/src/EventSubscriber/SearchApiSolrEventSubscriber.php
@@ -137,7 +137,8 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
       }
     }
     if ($query->getOption('sbf_knn')) {
-      error_log($solarium_query->getQuery());
+        //@TODO this is overly nested. I should also allow multiple ones like this
+        // then move any non KNN queries to "before" or to "filters"
       $solarium_query->setQuery($query->getOption('sbf_knn')[0][0]);
       $hl = $solarium_query->getHighlighting();
       // We can't highlight when doing Vector Queries or we will get

--- a/src/EventSubscriber/SearchApiSolrEventSubscriber.php
+++ b/src/EventSubscriber/SearchApiSolrEventSubscriber.php
@@ -195,14 +195,16 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
       $index = $item->getIndex();
       $solr_names = $index->getServerInstance()->getBackend()->getSolrFieldNames($index);
 
+
       foreach ($names as $name) {
         if (isset($solr_names[$name])) {
-          // Remove first. Solr Search API like 99% chances removed any 0.0 from a vector. Damn.
-          $document->setField($solr_names[$name], $item->getField($name)->getValues() ?? NULL);
+          // Why this check? I can't sent an empty. But i can send a NULL if not present
+          if (!empty($values = $item->getField($name)->getValues())) {
+            $document->setField($solr_names[$name], $item->getField($name)->getValues() ?? NULL);
+          }
         }
       }
     }
-    $document = $document;
   }
 
 

--- a/src/EventSubscriber/SearchApiSolrEventSubscriber.php
+++ b/src/EventSubscriber/SearchApiSolrEventSubscriber.php
@@ -97,10 +97,6 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
       $hl->setFragSize(128);
       $hl->setRequireFieldMatch(TRUE);
     }
-    // KNN here
-    if ($query->getOption('sbf_knn')) {
-      $solarium_query->getQuery();
-    }
   }
 
 
@@ -190,12 +186,9 @@ class SearchApiSolrEventSubscriber implements EventSubscriberInterface {
     }
 
     if (count($names) > 0) {
-
       $document = $event->getSolariumDocument();
       $index = $item->getIndex();
       $solr_names = $index->getServerInstance()->getBackend()->getSolrFieldNames($index);
-
-
       foreach ($names as $name) {
         if (isset($solr_names[$name])) {
           // Why this check? I can't sent an empty. But i can send a NULL if not present

--- a/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
@@ -83,7 +83,7 @@ class StrawberryEntitiesViaJmesPathFromJson extends StrawberryValuesViaJmesPathF
       $delta = 0;
       foreach ($this->processed as $reference) {
        // No way we can use  $this->createItem($delta, $reference); here
-       // Because our public facing datatype is not what it seems
+       // Because our public facing data_type is not what it seems
        // We can not use DataReferenceDefinitions here, we need actually EntityAdapter!
        // Because \Drupal\search_api\Utility\FieldsHelper::extractFields can only act
        // on Complexdatainterface elements

--- a/src/Plugin/search_api/data_type/DenseVector1024DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector1024DataType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\search_api\data_type;
+
+use Drupal\search_api\DataType\DataTypePluginBase;
+
+/**
+ * Provides a Vector data type for 1024 length search api fields.
+ *
+ * @SearchApiDataType(
+ *   id = "densevector_1024",
+ *   label = @Translation("Dense Vector of 1024 length"),
+ *   description = @Translation("Contains Dense Vectors, float values."),
+ *   fallback_type = "decimal",
+ *   prefix = "knn1024"
+ * )
+ */
+class DenseVector1024DataType extends DataTypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue($value) {
+    $value = (float) $value;
+    return $value;
+  }
+
+}

--- a/src/Plugin/search_api/data_type/DenseVector1024DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector1024DataType.php
@@ -21,7 +21,9 @@ class DenseVector1024DataType extends DataTypePluginBase {
    * {@inheritdoc}
    */
   public function getValue($value) {
-    $value = (float) $value;
+    if ($value !== NULL) {
+      $value = (float)$value;
+    }
     return $value;
   }
 

--- a/src/Plugin/search_api/data_type/DenseVector384DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector384DataType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\search_api\data_type;
+
+use Drupal\search_api\DataType\DataTypePluginBase;
+
+/**
+ * Provides a Vector data type for 384 length search api fields.
+ *
+ * @SearchApiDataType(
+ *   id = "densevector_384",
+ *   label = @Translation("Dense Vector of 384 length"),
+ *   description = @Translation("Contains Dense Vectors, float values."),
+ *   fallback_type = "decimal",
+ *   prefix = "knn384"
+ * )
+ */
+class DenseVector384DataType extends DataTypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue($value) {
+    $value = (float) $value;
+    return $value;
+  }
+
+}

--- a/src/Plugin/search_api/data_type/DenseVector384DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector384DataType.php
@@ -21,7 +21,9 @@ class DenseVector384DataType extends DataTypePluginBase {
    * {@inheritdoc}
    */
   public function getValue($value) {
-    $value = (float) $value;
+    if ($value !== NULL) {
+      $value = (float)$value;
+    }
     return $value;
   }
 

--- a/src/Plugin/search_api/data_type/DenseVector512DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector512DataType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\search_api\data_type;
+
+use Drupal\search_api\DataType\DataTypePluginBase;
+
+/**
+ * Provides a Vector data type for 512 length search api fields.
+ *
+ * @SearchApiDataType(
+ *   id = "densevector_512",
+ *   label = @Translation("Dense Vector of 512 length"),
+ *   description = @Translation("Contains Dense Vectors, float values."),
+ *   fallback_type = "decimal",
+ *   prefix = "knn512"
+ * )
+ */
+class DenseVector512DataType extends DataTypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue($value) {
+    $value = (float) $value;
+    return $value;
+  }
+
+}

--- a/src/Plugin/search_api/data_type/DenseVector512DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector512DataType.php
@@ -21,7 +21,9 @@ class DenseVector512DataType extends DataTypePluginBase {
    * {@inheritdoc}
    */
   public function getValue($value) {
-    $value = (float) $value;
+    if ($value !== NULL) {
+      $value = (float)$value;
+    }
     return $value;
   }
 

--- a/src/Plugin/search_api/data_type/DenseVector576DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector576DataType.php
@@ -21,7 +21,9 @@ class DenseVector576DataType extends DataTypePluginBase {
    * {@inheritdoc}
    */
   public function getValue($value) {
-    $value = (float) $value;
+    if ($value !== NULL) {
+      $value = (float)$value;
+    }
     return $value;
   }
 

--- a/src/Plugin/search_api/data_type/DenseVector576DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector576DataType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\search_api\data_type;
+
+use Drupal\search_api\DataType\DataTypePluginBase;
+
+/**
+ * Provides a Vector data type for 576 length search api fields.
+ *
+ * @SearchApiDataType(
+ *   id = "densevector_576",
+ *   label = @Translation("Dense Vector of 576 length"),
+ *   description = @Translation("Contains Dense Vectors, float values."),
+ *   fallback_type = "decimal",
+ *   prefix = "knn576"
+ * )
+ */
+class DenseVector576DataType extends DataTypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue($value) {
+    $value = (float) $value;
+    return $value;
+  }
+
+}

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -569,9 +569,7 @@ XML;
     ) {
       $status = $entity->isPublished();
       $uid = $entity->getOwnerId();
-      foreach (
-        $entity_ids_splitted[$entity_id] as $item_id => $splitted_id_for_node
-      ) {
+      foreach ($entity_ids_splitted[$entity_id] as $item_id => $splitted_id_for_node) {
         $sequence_id = !empty($splitted_id_for_node[1]) ? $splitted_id_for_node[1] : 1;
         $fid_uuid = isset($splitted_id_for_node[3]) ? $splitted_id_for_node[3] : NULL;
         // for Metadata only Processors we won't have a file. We will use the stub "ado" instead

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -355,16 +355,22 @@ XML;
         $entity_ids_splitted[$entity_id] as $item_id => $splitted_id_for_node
       ) {
         $fid_uuid = isset($splitted_id_for_node[3]) ? $splitted_id_for_node[3] : NULL;
-        $files = $this->entityTypeManager->getStorage('file')->loadByProperties(
-          [
-            'uuid' => $fid_uuid,
-          ]
-        );
-        $file = $files ? reset($files) : NULL;
-        if ($file) {
+        if ($fid_uuid && $fid_uuid!= 'ado') {
+          $files = $this->entityTypeManager->getStorage('file')->loadByProperties(
+            [
+              'uuid' => $fid_uuid,
+            ]
+          );
+          $file = $files ? reset($files) : NULL;
+          if ($file) {
+            $valid_item_ids[] = $item_id;
+          }
+          unset($file);
+        }
+        else {
+          // These are valid if no UUID is given at all for a file.
           $valid_item_ids[] = $item_id;
         }
-        unset($file);
       }
     }
     if (Utility::isRunningInCli()) {
@@ -619,9 +625,9 @@ XML;
           // For ML generated data. We will pre-validate
           $service_md5 =  isset($processed_data->service_md5) ? $processed_data->service_md5 : '';
           $vector_576 = isset($processed_data->vector_576) && is_array($processed_data->vector_576) && count($processed_data->vector_576) == 576 ? $processed_data->vector_576 : NULL;
-          $vector_512 = isset($processed_data->vector_576) && is_array($processed_data->vector_512) && count($processed_data->vector_512) == 512 ? $processed_data->vector_512 : NULL;
-          $vector_1024 = isset($processed_data->vector_576) && is_array($processed_data->vector_1024) && count($processed_data->vector_1024) == 1024 ? $processed_data->vector_1024 : NULL;
-          $vector_384 = isset($processed_data->vector_576) && is_array($processed_data->vector_576) && count($processed_data->vector_384) == 384 ? $processed_data->vector_384 : NULL;
+          $vector_512 = isset($processed_data->vector_512) && is_array($processed_data->vector_512) && count($processed_data->vector_512) == 512 ? $processed_data->vector_512 : NULL;
+          $vector_1024 = isset($processed_data->vector_1024) && is_array($processed_data->vector_1024) && count($processed_data->vector_1024) == 1024 ? $processed_data->vector_1024 : NULL;
+          $vector_384 = isset($processed_data->vector_384) && is_array($processed_data->vector_384) && count($processed_data->vector_384) == 384 ? $processed_data->vector_384 : NULL;
           $file_uuid = $file ?  $file->uuid() : NULL;
           $target_fileid = $file ? $file->id() : NULL;
           if ($checksum) {

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -568,24 +568,31 @@ XML;
       ) {
         $sequence_id = !empty($splitted_id_for_node[1]) ? $splitted_id_for_node[1] : 1;
         $fid_uuid = isset($splitted_id_for_node[3]) ? $splitted_id_for_node[3] : NULL;
+        // for Metadata only Processors we won't have a file. We will use the stub "ado" instead
+
         $plugin_id = isset($splitted_id_for_node[4]) ? $splitted_id_for_node[4] : NULL;
         $translation_id = isset($splitted_id_for_node[2]) ? $splitted_id_for_node[2] : NULL;
         // probably we will want to add the module/class namespace for the plugin id?
-        $files = $this->entityTypeManager->getStorage('file')->loadByProperties(
-          [
-            'uuid' => $fid_uuid,
-          ]
-        );
-        $file = $files ? reset($files) : NULL;
+        if ($fid_uuid && $fid_uuid != 'ado') {
+          $files = $this->entityTypeManager->getStorage('file')->loadByProperties(
+            [
+              'uuid' => $fid_uuid,
+            ]
+          );
+          $file = $files ? reset($files) : NULL;
+        }
 
-        if ($file && $plugin_id !== NULL
+        if (($file || $fid_uuid == 'ado') && $plugin_id !== NULL
           && ($processed_data
             = $this->getFlavorFromBackend($item_id))
         ) {
-          // Put the package File ID / Package.
+          // From 1.4.0 we will also allow Flavors that are purely metadata in its origin to exist.
+          // So file is an optional.
           $fulltext = isset($processed_data->fulltext) ? (string) $processed_data->fulltext : '';
           $label = isset($processed_data->label) ? (string) $processed_data->label : "Sequence {$sequence_id}";
           $plaintext = isset($processed_data->plaintext) ? (string) $processed_data->plaintext : '';
+          // Checksum will still exist, even if just metadata. That way on simple "ado" save if a processor
+          // is using metadata, if nothing changed we won't need to re-index.
           $checksum = isset($processed_data->checksum) ? (string) $processed_data->checksum : NULL;
           $where = isset($processed_data->where) ? (array) $processed_data->where : [];
           $where= preg_grep(
@@ -608,35 +615,49 @@ XML;
           $config_processor_id = isset($processed_data->config_processor_id) ? $processed_data->config_processor_id : '';
           $nlplang = isset($processed_data->nlplang) ? $processed_data->nlplang : [];
           $processlang = isset($processed_data->processlang) ? $processed_data->processlang : [];
+
+          // For ML generated data. We will pre-validate
+          $service_md5 =  isset($processed_data->service_md5) ? $processed_data->service_md5 : '';
+          $vector_576 = isset($processed_data->vector_576) && is_array($processed_data->vector_576) && count($processed_data->vector_576) == 576 ? $processed_data->vector_576 : NULL;
+          $vector_512 = isset($processed_data->vector_576) && is_array($processed_data->vector_512) && count($processed_data->vector_512) == 512 ? $processed_data->vector_512 : NULL;
+          $vector_1024 = isset($processed_data->vector_576) && is_array($processed_data->vector_1024) && count($processed_data->vector_1024) == 1024 ? $processed_data->vector_1024 : NULL;
+          $vector_384 = isset($processed_data->vector_576) && is_array($processed_data->vector_576) && count($processed_data->vector_384) == 384 ? $processed_data->vector_384 : NULL;
+          $file_uuid = $file ?  $file->uuid() : NULL;
+          $target_fileid = $file ? $file->id() : NULL;
           if ($checksum) {
             $data = [
-              'item_id'             => $item_id,
-              'label'               => $label,
-              'sequence_id'         => $sequence_id,
-              'sequence_total'      => $sequence_total,
-              'target_id'           => $entity_id,
-              'parent_id'           => $entity_id,
-              'file_uuid'           => $file->uuid(),
-              'target_fileid'       => $file->id(),
+              'item_id' => $item_id,
+              'label' => $label,
+              'sequence_id' => $sequence_id,
+              'sequence_total' => $sequence_total,
+              'target_id' => $entity_id,
+              'parent_id' => $entity_id,
+              'file_uuid' => $file_uuid,
+              'target_fileid' => $target_fileid,
               'config_processor_id' => $config_processor_id,
-              'processor_id'        => $plugin_id,
-              'fulltext'            => '',
-              'plaintext'           => '',
-              'metadata'            => $metadata,
-              'who'                 => $who,
-              'nlplang'             => $nlplang,
-              'processlang'         => $processlang,
-              'where'               => $where,
-              'when'                => $when,
-              'ts'                  => $ts,
-              'sentiment'           => $sentiment,
-              'uri'                 => $uri,
-              'checksum'            => $checksum,
-              'status'              => $status,
-              'uid'                 => $uid,
+              'processor_id' => $plugin_id,
+              'fulltext' => '',
+              'plaintext' => '',
+              'metadata' => $metadata,
+              'who' => $who,
+              'nlplang' => $nlplang,
+              'processlang' => $processlang,
+              'where' => $where,
+              'when' => $when,
+              'ts' => $ts,
+              'sentiment' => $sentiment,
+              'uri' => $uri,
+              'checksum' => $checksum,
+              'status' => $status,
+              'uid' => $uid,
+              'service_md5' => $service_md5,
+              'vector_384' => $vector_384,
+              'vector_512' => $vector_512,
+              'vector_576' => $vector_576,
+              'vector_1024' => $vector_1024
             ];
             // This will then always create a new Index document, even if empty.
-            // Needed if we e.g are gonna use this for Book search/IIIF search
+            // Needed if we e.g. want to use this for Book search/IIIF search
             // to make sure it at least exists!
             if (!empty(trim($fulltext))) {
               try {
@@ -671,7 +692,7 @@ XML;
                 str_replace("<l>", PHP_EOL . "<l> ", $data['plaintext'])
               );
             }
-
+            // TODO. What if we wrap this in a try/catch?
             $documents[$item_id] = $this->typedDataManager->create(
               $sbfflavordata_definition
             );
@@ -994,6 +1015,7 @@ XML;
    * @return mixed
    */
   public function getFlavorFromBackend($item_id) {
+    //@TODO work an alternative backends.
     return $this->keyValue->get(self::SBFL_KEY_COLLECTION)->get(
       $item_id
     );

--- a/src/Plugin/search_api/processor/StrawberryFieldHighlight.php
+++ b/src/Plugin/search_api/processor/StrawberryFieldHighlight.php
@@ -435,7 +435,9 @@ class StrawberryFieldHighlight extends Highlight implements PluginFormInterface 
       // This assumes we are indeed using phrase escaping (see \Drupal\search_api_solr\Utility\Utility::flattenKeys)
       // And not term escaping (which would be desired for single keys
       // but then i will not re-write code from \Drupal\search_api_solr!
-      preg_match_all('/"([^"]+)"/', $direct_keys,$match);
+      if (!empty($direct_keys)) {
+        preg_match_all('/"([^"]+)"/', $direct_keys, $match);
+      }
       if (isset($match[1]) && is_array($match[1])) {
         $keys = array_unique($match[1]);
       }

--- a/src/StrawberryFieldBreadcrumbBuilder.php
+++ b/src/StrawberryFieldBreadcrumbBuilder.php
@@ -121,7 +121,7 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     }
     $breadcrumb->setLinks($links);
     $breadcrumb->addCacheTags(['config:strawberryfield.breadcrumbs']);
-    $breadcrumb->addCacheContexts(['route']);
+    $breadcrumb->addCacheContexts(['route', 'url.path', 'languages']);
     return $breadcrumb;
   }
 

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -60,7 +60,7 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info['vector_1024'] = ListDataDefinition::create('float')->setLabel('Vector of size 1024 coming from ML')->addConstraint('Length', ['max' => 1024]);
       $info['vector_384'] = ListDataDefinition::create('float')->setLabel('Vector of size 384 coming from ML')->addConstraint('Length', ['max' => 384]);
       $info['vector_512'] = ListDataDefinition::create('float')->setLabel('Vector of size 512 coming from ML')->addConstraint('Length', ['max' => 512]);
-      return $this->propertyDefinitions;
     }
+    return $this->propertyDefinitions;
   }
 }

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -17,8 +17,7 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
    * {@inheritdoc}
    */
   public function getPropertyDefinitions() {
-
-    if(!isset($this->propertyDefinitions)){
+    if (!isset($this->propertyDefinitions)) {
       $info = &$this->propertyDefinitions;
       $info['item_id'] = DataDefinition::create('string')->setLabel('Item ID');
       $info['label'] = DataDefinition::create('string')->setLabel('A Label');
@@ -50,13 +49,18 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info['when'] = ListDataDefinition::create('string')->setLabel('Ordered list of dates in string format');
       $info['sentiment'] = DataDefinition::create('string')->setLabel('Sentiment in integer range');
       $info['nlplang'] = ListDataDefinition::create('string')->setLabel('Ordered list of nlp detected languages');
-      $info['processlang'] = ListDataDefinition::create('string')->setLabel('Ordered list of languages provided to process nnmodified data body');
+      $info['processlang'] = ListDataDefinition::create('string')->setLabel('Ordered list of languages provided to process unmodified data body');
       $info['ts'] = DataDefinition::create('string')->setLabel('A Time stamp');
       //§/ required by Content Access processor , maybe we can disable it in some manner
       $info['status'] = DataDefinition::create('boolean')->setLabel('Status');
       $info['uid'] = DataDefinition::create('integer')->setLabel('UID');
+      // New For ML
+      $info['service_md5'] = DataDefinition::create('string')->setLabel('An MD5 checksum characterizing the Service that generated the values');
+      $info['vector_576'] = ListDataDefinition::create('float')->setLabel('Vector of size 576 coming from ML')->addConstraint('Length', ['max' => 576]);
+      $info['vector_1024'] = ListDataDefinition::create('float')->setLabel('Vector of size 1024 coming from ML')->addConstraint('Length', ['max' => 1024]);
+      $info['vector_384'] = ListDataDefinition::create('float')->setLabel('Vector of size 384 coming from ML')->addConstraint('Length', ['max' => 384]);
+      $info['vector_512'] = ListDataDefinition::create('float')->setLabel('Vector of size 512 coming from ML')->addConstraint('Length', ['max' => 512]);
+      return $this->propertyDefinitions;
     }
-    return $this->propertyDefinitions;
   }
-
 }


### PR DESCRIPTION
See #325 

This stuff works now.

Requires a fixed entry in schema_extra_fields.xml

like 

```XML
<!-- ML/vectors -->
<dynamicField name="knn576m_*" type="knn_vector_576" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn576s_*" type="pfloat" stored="true" indexed="true" multiValued="false" />
<dynamicField name="knn512m_*" type="knn_vector_512" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn512s_*" type="pfloat" stored="true" indexed="true" multiValued="false" />
<dynamicField name="knn1024m_*" type="knn_vector_1024" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn1024s_*" type="pfloat" stored="true" indexed="true" multiValued="false" />
<dynamicField name="knn3846m_*" type="knn_vector_384" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn384s_*" type="pfloat" stored="true" indexed="true" multiValued="false" />
<dynamicField name="knn576m_X3b_und_*" type="knn_vector_576" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn576s_X3b_und_*" type="pfloat" stored="true" indexed="true" multiValued="false" />
<dynamicField name="knn512m_X3b_und_*" type="knn_vector_512" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn512s_X3b_und_*" type="pfloat" stored="true" indexed="true" multiValued="false" />
<dynamicField name="knn1024m_X3b_und_*" type="knn_vector_1024" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn1024s_X3b_und_*" type="pfloat" stored="true" indexed="true" multiValued="false" />
<dynamicField name="knn3846m_X3b_und_*" type="knn_vector_384" stored="true" indexed="true" multiValued="false"/>
<dynamicField name="knn384s_X3b_und_*" type="pfloat" stored="true" indexed="true" multiValued="false" />

```

plus the provided types in `schema_extra_types.xml`
```XML
<!--
  Dense Vector Field of 384 dimensions suitable for Bert text feature extraction (embeddings) using dot_product as comparison algorithm
  9.0.0
-->
<fieldType name="knn_vector_384" class="solr.DenseVectorField" vectorDimension="384" similarityFunction="dot_product"/>
<!--
  Dense Vector Field of 512 dimensions suitable for Apple Vision ML Image FingerPrint (embeddings) using dot_product as comparison algorithm
  9.0.0
-->
<fieldType name="knn_vector_512" class="solr.DenseVectorField" vectorDimension="512" similarityFunction="dot_product"/>
<!--
  Dense Vector Field of 576 dimensions suitable for YOLOv8 feature extraction using dot_product as comparison algorithm
  9.0.0
-->
<fieldType name="knn_vector_576" class="solr.DenseVectorField" vectorDimension="576" similarityFunction="dot_product"/>
<!--
  Dense Vector Field of 1024 dimensions suitable for mobileNetV3 feature extraction (embeddings) using dot_product as comparison algorithm
  9.0.0
-->
<fieldType name="knn_vector_1024" class="solr.DenseVectorField" vectorDimension="1024" similarityFunction="dot_product"/>
```

Supporting code provided by https://github.com/esmero/strawberry_runners/pull/92