### PR TITLE
ISSUE-330: Don't re-track parent Nodes of a flavor if not actively indexing

### DIFF
--- a/src/Plugin/Action/StrawberryfieldJsonPatch.php
+++ b/src/Plugin/Action/StrawberryfieldJsonPatch.php
@@ -27,6 +27,7 @@ use Swaggest\JsonDiff\JsonDiff;
  * @Action(
  *   id = "entity:jsonpatch_action",
  *   action_label = @Translation("JSON Patch an ADO"),
+ *   label = @Translation("JSON Patch an ADO"),
  *   category = @Translation("Metadata"),
  *   type = "node"
  * )

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -743,7 +743,6 @@ XML;
     }
 
     if ($this->searchApiStateHelper->isIndexing()) {
-      error_log('we are indexing now');
       /** @var \Drupal\search_api\Plugin\search_api\datasource\ContentEntityTrackingManager $tracking_manager */
       $tracking_manager = \Drupal::getContainer()
         ->get('search_api.entity_datasource.tracking_manager');
@@ -756,9 +755,6 @@ XML;
           $index->trackItemsUpdated('entity:node', array_keys($items_by_bundle));
         }
       }
-    }
-    else {
-      error_log('fetched flavor but not indexing');
     }
 
     return $documents;

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -18,6 +18,7 @@ use Drupal\search_api\Plugin\PluginFormTrait;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Plugin\PluginDependencyTrait;
+use Drupal\strawberryfield\StrawberryfieldSearchAPIUtilityServiceInterface;
 
 /**
  * Represents a datasource which exposes flavors.
@@ -78,6 +79,12 @@ XML;
    */
   protected $configFactory;
 
+  /**
+   * The SBF Search API State (indexing) helper.
+   *
+   * @var \Drupal\strawberryfield\StrawberryfieldSearchAPIUtilityServiceInterface;
+   */
+  protected $searchApiStateHelper;
 
   /**
    * The entity field manager.
@@ -140,6 +147,7 @@ XML;
     $datasource->languageManager = $container->get('language_manager');
     $datasource->keyValue = $container->get('strawberryfield.keyvalue.database');
     $datasource->state = $container->get('state');
+    $datasource->searchApiStateHelper = $container->get('strawberryfield.search_api_state_helper');
     return $datasource;
   }
 
@@ -705,7 +713,7 @@ XML;
           // As good as we can here
           // Try avoiding tracking for update if we are still processing partial sequences
           // This will of course make no difference for Single Files/Single Sequence.
-          if ($sequence_id == $sequence_total) {
+          if (($sequence_id == $sequence_total) && $this->searchApiStateHelper->isIndexing()) {
             // We store the entity. That way we can get the parents
             // out of it.
             // We don't know much at this stage
@@ -734,17 +742,23 @@ XML;
       }
     }
 
-    /** @var \Drupal\search_api\Plugin\search_api\datasource\ContentEntityTrackingManager $tracking_manager */
-    $tracking_manager = \Drupal::getContainer()
-      ->get('search_api.entity_datasource.tracking_manager');
-    // We don't want to do this many times. We only need to call fetching the index once
-    // Per bundle.
-    foreach ($content_item_ids_to_update as $bundle => $items_by_bundle) {
-      $one_entity = reset($items_by_bundle);
-      $indexes = $tracking_manager->getIndexesForEntity($one_entity);
-      foreach ($indexes as $index) {
-        $index->trackItemsUpdated('entity:node', array_keys($items_by_bundle));
+    if ($this->searchApiStateHelper->isIndexing()) {
+      error_log('we are indexing now');
+      /** @var \Drupal\search_api\Plugin\search_api\datasource\ContentEntityTrackingManager $tracking_manager */
+      $tracking_manager = \Drupal::getContainer()
+        ->get('search_api.entity_datasource.tracking_manager');
+      // We don't want to do this many times. We only need to call fetching the index once
+      // Per bundle.
+      foreach ($content_item_ids_to_update as $bundle => $items_by_bundle) {
+        $one_entity = reset($items_by_bundle);
+        $indexes = $tracking_manager->getIndexesForEntity($one_entity);
+        foreach ($indexes as $index) {
+          $index->trackItemsUpdated('entity:node', array_keys($items_by_bundle));
+        }
       }
+    }
+    else {
+      error_log('fetched flavor but not indexing');
     }
 
     return $documents;

--- a/src/Plugin/search_api/processor/StrawberryFlavorAggregate.php
+++ b/src/Plugin/search_api/processor/StrawberryFlavorAggregate.php
@@ -161,11 +161,9 @@ class StrawberryFlavorAggregate extends ProcessorPluginBase {
                 array_map('trim', $processor_ids)
               );
               foreach ($processor_ids as $processor_id) {
-
                 $flavors = $this->flavorsfromSolrIndex(
                   $node->id(), $processor_id, $indexes,  50, 500
                 );
-
                 $flavors = array_filter($flavors);
                 if (count($flavors)) {
                   $flavors = array_values($flavors);


### PR DESCRIPTION
See #330 

This also fixes a deprecation VBO introduced where all `action_labels` now need to be `label`. So silly.