### PR TITLE
issues/333-jmespath-splitting ---> 1.4.0

### DIFF
--- a/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryEntitiesViaJmesPathFromJson.php
@@ -64,7 +64,9 @@ class StrawberryEntitiesViaJmesPathFromJson extends StrawberryValuesViaJmesPathF
       // jmespath's separated by comma.
       $jmespaths = $definition['settings']['jsonkey'];
       $entity_type = $definition['settings']['entitytype'] ?? 'node';
-      $jmespath_array = array_map('trim', explode(',', $jmespaths));
+      // See https://github.com/esmero/strawberryfield/issues/333
+      $pattern = '/[,]+(?![^\[]*\]|[^\(]*\)|[^\{]*\})/';
+      $jmespath_array = array_map('trim', preg_split($pattern, $jmespaths));
       $jmespath_result = [];
       foreach ($jmespath_array as $jmespath) {
         $jmespath_result[] = $item->searchPath(trim($jmespath ?? ''),FALSE);

--- a/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
+++ b/src/Plugin/DataType/StrawberryValuesViaJmesPathFromJson.php
@@ -60,7 +60,9 @@ class StrawberryValuesViaJmesPathFromJson extends ItemList {
       // jmespath's separated by comma.
       $jmespaths = $definition['settings']['jsonkey'];
       $is_date = $definition['settings']['is_date'] ?? FALSE;
-      $jmespath_array = array_map('trim', explode(',', $jmespaths));
+      // See https://github.com/esmero/strawberryfield/issues/333
+      $pattern = '/[,]+(?![^\[]*\]|[^\(]*\)|[^\{]*\})/';
+      $jmespath_array = array_map('trim', preg_split($pattern, $jmespaths));
       $jmespath_result = [];
       foreach ($jmespath_array as $jmespath) {
         $jmespath_result[] = $item->searchPath(trim($jmespath),FALSE);


### PR DESCRIPTION
 Use preg_split with regex to explode comma-separated jmespaths into individual jmespaths because individual jmespaths may contain commas.

See https://github.com/esmero/strawberryfield/issues/333