### PR TITLE
ISSUE-344: allow a file re-manage attempt using ap:task entry

### DIFF
--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -795,7 +795,9 @@ class StrawberryfieldFilePersisterService {
               // We need to remove this now. Can't run again.
               if ($force_file_manage) {
                 $fullvalues = $itemfield->provideDecoded(TRUE);
-                unset($fullvalues[["ap:tasks"]["ap:forcefilemanage"]]);
+
+                unset($fullvalues["ap:tasks"]["ap:forcefilemanage"]);
+
                 if (!$itemfield->setMainValueFromArray((array) $fullvalues)) {
                   $this->messenger->addError($this->t('We failed unsetting ap:forcefilemanage. Please remove manually.'));
                 }

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -784,8 +784,25 @@ class StrawberryfieldFilePersisterService {
               // Naming service will always try to name things in a certain
               // way. So either we allow both to act everytime or we
               // have a other 'move your files' service?
+
+
+              // New option. {
+              //    "ap:tasks": {
+              //        "ap:forcefilemanage": true
+              //    }
+              //}
+              $force_file_manage =  $flatvalues["ap:tasks"]["ap:forcefilemanage"] ?? FALSE;
+              // We need to remove this now. Can't run again.
+              if ($force_file_manage) {
+                $fullvalues = $itemfield->provideDecoded(TRUE);
+                unset($fullvalues[["ap:tasks"]["ap:forcefilemanage"]]);
+                if (!$itemfield->setMainValueFromArray((array) $fullvalues)) {
+                  $this->messenger->addError($this->t('We failed unsetting ap:forcefilemanage. Please remove manually.'));
+                }
+              }
+
               $scheme = $file ? $this->streamWrapperManager::getScheme($file->getFileUri()) : NULL;
-              if ($file && ($file->isTemporary() || $scheme == 'temporary')) {
+              if ($file && ($file->isTemporary() || $scheme == 'temporary' || $force_file_manage)) {
                 // This is tricky. We will allow non temporary to be moved if
                 // The only usage is the current node!
                 $uuid = $file->uuid();
@@ -820,7 +837,7 @@ class StrawberryfieldFilePersisterService {
                         $destination_uri
                       );
                     }
-                    // Means moving was successful
+                    // Means copying was successful
                     if ($destination_uri) {
                       $file->setFileUri($destination_uri);
                     }

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -767,7 +767,9 @@ class StrawberryfieldFilePersisterService {
       $entity = $field->getEntity();
       $entity_type_id = $entity->getEntityTypeId();
       foreach ($field->getIterator() as $delta => $itemfield) {
-        // Note: we are not longer touching the metadata here.
+        // Note: we are not longer touching the metadata here except under the presence of ap:forcefilemanage.
+        // @TODO. WE should disallow that key on new entities?
+        // Also add a special permission.
         /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
         $flatvalues = (array) $itemfield->provideFlatten();
         if (isset($flatvalues['dr:fid'])) {


### PR DESCRIPTION
See #344 

This adds `{"ap:tasks": {"ap:forcefilemanage"}}`. If for some reason the original manage attempt of Archipelago fails (means moving to the final location stated inside :
```
"urn:uuid:someuuid": {
            "type": "sometime",
            "url": "s3:\/\/76f\/somefile-finaldestination-and-desired-location.extension",
            "crypHashFunc": "md5",
...
```
Archipelago, for safety will keep using the original location of the file and mark the `file` entity as "permanent" so nobody gets rid of it during CRON temp file disposal. But also permanent means we won't try again (intended)

But of course, IIIF (Cantaloupe) won't be able to access the file and from there one very hard to get it done correctly. This new key allows an ADO to attempt again this even if the File is already Permanent. if the location already matches the `url` key previously shown here no extra processing will happen.

Once the `ap:task` was executed, archipelago will remove it from the JSON so it does not run again. This changes the "idea" that the file persister will never modify metadata but, it is the only way.
