### PR TITLE
ISSUE-347: new Vector (*768) and a new internal sequence for Flavor IDs *using a dash*

### DIFF
--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_768_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_768_und_9_0_0.yml
@@ -1,0 +1,21 @@
+uuid: 3ddbbe04-b91d-487f-ba86-cf77e12e07a7
+langcode: en
+status: true
+dependencies:
+  module:
+    - strawberryfield
+    - search_api_solr
+id: dense_vector_field_768_und
+label: 'Dense Vector Field of 768 dimensions suitable for ViT feature extraction using dot_product as comparison algorithm'
+minimum_solr_version: 9.0.0
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: knn_vector_768
+  class: solr.DenseVectorField
+  vectorDimension: 768
+  similarityFunction: dot_product
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+text_files: {  }

--- a/src/Plugin/search_api/data_type/DenseVector768DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector768DataType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\search_api\data_type;
+
+use Drupal\search_api\DataType\DataTypePluginBase;
+
+/**
+ * Provides a Vector data type for 768 length search api fields.
+ *
+ * @SearchApiDataType(
+ *   id = "densevector_768",
+ *   label = @Translation("Dense Vector of 768 length"),
+ *   description = @Translation("Contains Dense Vectors, float values."),
+ *   fallback_type = "decimal",
+ *   prefix = "knn768"
+ * )
+ */
+class DenseVector768DataType extends DataTypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue($value) {
+    if ($value !== NULL) {
+      $value = (float)$value;
+    }
+    return $value;
+  }
+
+}

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -21,8 +21,11 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info = &$this->propertyDefinitions;
       $info['item_id'] = DataDefinition::create('string')->setLabel('Item ID');
       $info['label'] = DataDefinition::create('string')->setLabel('A Label');
-      $info['sequence_id'] = DataDefinition::create('string')->setLabel('Sequence ID');
-      $info['sequence_total'] = DataDefinition::create('string')->setLabel('Expected total sequence count');
+      // Image based offset. e.g PDF with 2 means second page. Inside the same image
+      $info['sequence_id'] = DataDefinition::create('string')->setLabel('Sequence ID. e.g for PDF, second Page, will be 2');
+      // Inside the same Image internal sequence_id. E.g a single JPEG with 5 annotations.
+      $info['internal_sequence_id'] = DataDefinition::create('string')->setLabel('Internal Sequence ID. PDF, second Page, first ML annotation will be 1.');
+      $info['sequence_total'] = DataDefinition::create('string')->setLabel('Expected total sequence count of sequence_id values');
       $info['uri'] = DataDefinition::create('string')->setLabel('A source or related Uri/URL');
       $info['checksum'] = DataDefinition::create('string')->setLabel('Checksum that can be used to check if the source needs reprocessing');
       $info['processor_id'] = DataDefinition::create('string')->setLabel('Processor Plugin id that populated this data');
@@ -60,6 +63,7 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info['vector_1024'] = ListDataDefinition::create('float')->setLabel('Vector of size 1024 coming from ML')->addConstraint('Length', ['max' => 1024]);
       $info['vector_384'] = ListDataDefinition::create('float')->setLabel('Vector of size 384 coming from ML')->addConstraint('Length', ['max' => 384]);
       $info['vector_512'] = ListDataDefinition::create('float')->setLabel('Vector of size 512 coming from ML')->addConstraint('Length', ['max' => 512]);
+      $info['vector_768'] = ListDataDefinition::create('float')->setLabel('Vector of size 768 coming from ML')->addConstraint('Length', ['max' => 768]);
     }
     return $this->propertyDefinitions;
   }


### PR DESCRIPTION
See #347

The new SBF ID structure (for Solr) allows a dash. Only ML generated SBF have this allowing a File level sequence (e.g a PDF, let's say Page 2) to have a subsequence, e.g Annotation 1, 2, 3.

Basically allowing something like this
```JSON
{"id":"3byiu5-default_solr_index-strawberryfield_flavor_datasource/313796:1-2:en:548e48f0-a703-4101-875c-b6f9779c5dbf:chained_mobilenet_child"}

````   
  Notice the 
 ` 313796:1-2` being 313796 the NODE, 1 the File level sequence (1 by default, and -2) being the second annotation generate by an ML Processor

IIIF Content Search API (Format Strawberryfield) will also get a pull to allow that second level one to not confuse the search/matching (tested, works well)
