### PR TITLE
ISSUE-349 + 768 Vector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.1",
         "ext-json": "*",
         "drupal/core": ">=9.5 || ^10",
         "ml/json-ld": "~1.1",

--- a/config/install/search_api_solr.solr_field_type.dense_vector_field_768_und_9_0_0.yml
+++ b/config/install/search_api_solr.solr_field_type.dense_vector_field_768_und_9_0_0.yml
@@ -1,0 +1,21 @@
+uuid: 3ddbbe04-b91d-487f-ba86-cf77e12e07a7
+langcode: en
+status: true
+dependencies:
+  module:
+    - strawberryfield
+    - search_api_solr
+id: dense_vector_field_768_und
+label: 'Dense Vector Field of 768 dimensions suitable for ViT feature extraction using dot_product as comparison algorithm'
+minimum_solr_version: 9.0.0
+field_type_language_code: und
+domains: {  }
+field_type:
+  name: knn_vector_768
+  class: solr.DenseVectorField
+  vectorDimension: 768
+  similarityFunction: dot_product
+unstemmed_field_type: null
+spellcheck_field_type: null
+collated_field_type: null
+text_files: {  }

--- a/src/EventSubscriber/StrawberryfieldEventCompostBinSubscriber.php
+++ b/src/EventSubscriber/StrawberryfieldEventCompostBinSubscriber.php
@@ -60,7 +60,7 @@ class StrawberryfieldEventCompostBinSubscriber implements EventSubscriberInterfa
    */
   public function onTempFilePushed(StrawberryfieldFileEvent $event) {
     // Not much here to see. The Queue Worker does the logic
-    // We want to be quick as quick as we can.
+    // We want to be quick, as quick as we can.
     $data = new \stdClass();
     $data->uri = $event->getURI();
     $data->module = $event->getModule();

--- a/src/KeyValueStore/DatabaseStorageWithIndex.php
+++ b/src/KeyValueStore/DatabaseStorageWithIndex.php
@@ -54,7 +54,7 @@ class DatabaseStorageWithIndex extends DatabaseStorage {
       $values = [];
       foreach ($result as $item) {
         if ($item) {
-          $values[$item->name] = $values[$item->name];
+          $values[$item->name] = $item->name;
         }
       }
       return $values;

--- a/src/Plugin/Field/FieldType/StrawberryFieldItem.php
+++ b/src/Plugin/Field/FieldType/StrawberryFieldItem.php
@@ -241,7 +241,7 @@ use Drupal\strawberryfield\Tools\StrawberryfieldJsonHelper;
     * {@inheritdoc}
     */
    public function isEmpty() {
-     // Lets optimize.
+     // Let's optimize.
      // All our properties are computed
      // So if main value is empty rest will be too
      $mainproperty = $this->mainPropertyName();

--- a/src/Plugin/search_api/data_type/DenseVector768DataType.php
+++ b/src/Plugin/search_api/data_type/DenseVector768DataType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\strawberryfield\Plugin\search_api\data_type;
+
+use Drupal\search_api\DataType\DataTypePluginBase;
+
+/**
+ * Provides a Vector data type for 768 length search api fields.
+ *
+ * @SearchApiDataType(
+ *   id = "densevector_768",
+ *   label = @Translation("Dense Vector of 768 length"),
+ *   description = @Translation("Contains Dense Vectors, float values."),
+ *   fallback_type = "decimal",
+ *   prefix = "knn768"
+ * )
+ */
+class DenseVector768DataType extends DataTypePluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getValue($value) {
+    if ($value !== NULL) {
+      $value = (float)$value;
+    }
+    return $value;
+  }
+
+}

--- a/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
+++ b/src/Plugin/search_api/datasource/StrawberryfieldFlavorDatasource.php
@@ -844,7 +844,7 @@ XML;
    * Retrieves the entity display repository.
    *
    * @return \Drupal\Core\Entity\EntityDisplayRepositoryInterface
-   *   The entity entity display repository.
+   *   The entity display repository.
    */
   protected function getEntityDisplayRepository() {
     return $this->entityDisplayRepository ?: \Drupal::service(

--- a/src/StrawberryfieldUtilityServiceInterface.php
+++ b/src/StrawberryfieldUtilityServiceInterface.php
@@ -147,6 +147,35 @@ interface StrawberryfieldUtilityServiceInterface {
   public function getCountByProcessorInSolr(EntityInterface $entity, string $processor, array $indexes = [], string $checksum = NULL): int;
 
   /**
+   * Gets the number of documents that match an entity and processor.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   *   Entity to search for.
+   * @param array $processors
+   *   Processors to filter, e.g. ocr.
+   * @param string $processor_op
+   *    Accepted values are OR/AND
+   * @param bool $direct
+   *    Find directly on ADO
+   * @param bool $children
+   *    Find on ADO children
+   * @param bool $grandchildren
+   *    Find on ADO GrandChildren
+   * @param string $level_op
+   *    If count is OR/AND of the previos direct, children of grandchildren bool
+   * @param \Drupal\search_api\IndexInterface[] $indexes
+   *   Indexes that are searched, empty for all indexes. (optiona)
+   * @return int
+   *   Count of documents found.
+   *
+   * @throws \Drupal\search_api\SearchApiException
+   */
+  public function getCountByProcessorsAndLevelInSolr(EntityInterface $entity, array $processors, string $processor_op = 'OR', bool $direct = TRUE, bool $children = FALSE, bool $grandchildren = FALSE, string $level_op = 'OR',  array $indexes = []): int;
+
+
+
+
+  /**
    * Determines if a file system path is valid and can be written to.
    * Utilizes more restrictive Amazon S3 file prefix rules that are
    * described here: https://www.ezs3.com/public/232.cfm:

--- a/src/Tools/StrawberryfieldJsonHelper.php
+++ b/src/Tools/StrawberryfieldJsonHelper.php
@@ -447,7 +447,7 @@ class StrawberryfieldJsonHelper {
         $value = is_string($data['value']) ? "'" . $data['value'] . "'" : "`" . $data['value'] . "`";
       }
       else {
-        // Maybe there is a smater way?
+        // Maybe there is a smarter way?
         $value = "`null`";
       }
       if (in_array($data['op'], self::JMESPATH_FILTER_COMPARATOR)) {
@@ -598,7 +598,7 @@ class StrawberryfieldJsonHelper {
    *
    * @return bool|array
    * @throws \Exception
-   */  
+   */
   public static function isValidJsonSchema(string $jsonstring, string $acceptedjsonschema) {
     $jsonarray = json_decode(trim($jsonstring));
     $json_error = json_last_error();

--- a/src/TypedData/StrawberryfieldFlavorDataDefinition.php
+++ b/src/TypedData/StrawberryfieldFlavorDataDefinition.php
@@ -21,8 +21,11 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info = &$this->propertyDefinitions;
       $info['item_id'] = DataDefinition::create('string')->setLabel('Item ID');
       $info['label'] = DataDefinition::create('string')->setLabel('A Label');
-      $info['sequence_id'] = DataDefinition::create('string')->setLabel('Sequence ID');
-      $info['sequence_total'] = DataDefinition::create('string')->setLabel('Expected total sequence count');
+      // Image based offset. e.g PDF with 2 means second page. Inside the same image
+      $info['sequence_id'] = DataDefinition::create('string')->setLabel('Sequence ID. e.g for PDF, second Page, will be 2');
+      // Inside the same Image internal sequence_id. E.g a single JPEG with 5 annotations.
+      $info['internal_sequence_id'] = DataDefinition::create('string')->setLabel('Internal Sequence ID. PDF, second Page, first ML annotation will be 1.');
+      $info['sequence_total'] = DataDefinition::create('string')->setLabel('Expected total sequence count of sequence_id values');
       $info['uri'] = DataDefinition::create('string')->setLabel('A source or related Uri/URL');
       $info['checksum'] = DataDefinition::create('string')->setLabel('Checksum that can be used to check if the source needs reprocessing');
       $info['processor_id'] = DataDefinition::create('string')->setLabel('Processor Plugin id that populated this data');
@@ -60,6 +63,7 @@ class StrawberryfieldFlavorDataDefinition extends ComplexDataDefinitionBase {
       $info['vector_1024'] = ListDataDefinition::create('float')->setLabel('Vector of size 1024 coming from ML')->addConstraint('Length', ['max' => 1024]);
       $info['vector_384'] = ListDataDefinition::create('float')->setLabel('Vector of size 384 coming from ML')->addConstraint('Length', ['max' => 384]);
       $info['vector_512'] = ListDataDefinition::create('float')->setLabel('Vector of size 512 coming from ML')->addConstraint('Length', ['max' => 512]);
+      $info['vector_768'] = ListDataDefinition::create('float')->setLabel('Vector of size 768 coming from ML')->addConstraint('Length', ['max' => 768]);
     }
     return $this->propertyDefinitions;
   }


### PR DESCRIPTION
# What? 

Adds a helper method that counts Flavours at different hierarchies (Direct, Children, Grandchildren) using configurable OR/AND 

Also adds the 768 Vector, the ability to have sub-flavor ids (needed for ML when a single PDF generates multiple annotations/detections) and some small Release bug fixes when re-tracking Flavour data sources at the Search API index level (we had some WARNINGs there) + Typo corrections