### PR TITLE
ISSUE-352 (backwards patch for 1.4.0): Composter would not allow JSON API uploaded files to be cleaned + 10.3 JSON API and Field info changes #353

### DIFF
--- a/src/Plugin/QueueWorker/CompostQueueWorker.php
+++ b/src/Plugin/QueueWorker/CompostQueueWorker.php
@@ -186,12 +186,21 @@ class CompostQueueWorker extends QueueWorkerBase implements ContainerFactoryPlug
     $unsafe_prefix = ["."];
     $unsafe_suffix = [".php", ".conf", ".yml", "settings"];
 
+    // See \strawberryfield_entity_base_field_info()
+    // field_file_drop (computed) field used by JSON API ingest needs to be in the
+    // safe_paths too.
+    $scheme_options_for_field_file_drop = 'public';
+    if ( $this->streamWrapperManager->isValidScheme('private')) {
+      $scheme_options_for_field_file_drop = 'private';
+    }
+
     $safe_paths
       = $safe_paths_default = [
       $this->fileSystem->getTempDirectory(),
       'temporary://',
       'private://webform/',
-      's3://webform/'
+      's3://webform/',
+      $scheme_options_for_field_file_drop.'://sbf_tmp/'
     ];
     $this->moduleHandler->alter(
       'strawberryfield_compost_safe_basepaths',

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -166,15 +166,14 @@ function strawberryfield_entity_base_field_info(EntityTypeInterface $entity_type
   if ($entity_type->id() != 'node') {
     return [];
   }
-  $scheme_options = \Drupal::service('stream_wrapper_manager')->getNames(StreamWrapperInterface::WRITE_VISIBLE);
-  if (isset($scheme_options['private'])) {
+  /** @var \Drupal\Core\StreamWrapper\StreamWrapperManagerInterface $stream_wrapper_manager */
+  $stream_wrapper_manager = \Drupal::service('stream_wrapper_manager');
+  // WOW. Since Drupal 10.4, after a cache clear, this function is no longer working.
+  // Chances are the hook_entity_base_field_info is called before the streamwrappers are registered
+  //$scheme_options = $stream_wrapper_manager->getNames(StreamWrapperInterface::WRITE_VISIBLE);
+  $schema = 'public';
+  if ($stream_wrapper_manager->isValidScheme('private')) {
     $schema = 'private';
-  }
-  elseif (isset($scheme_options['public'])) {
-    $schema = 'public';
-  }
-  else {
-    $schema = 'public';
   }
 
   $fields = [];
@@ -192,6 +191,10 @@ function strawberryfield_entity_base_field_info(EntityTypeInterface $entity_type
   // BaseFieldDefinition.
   // That manages without hickups the 'Bundle' option
   // \Drupal\Core\Field\BaseFieldDefinition::setTargetBundle
+
+  // @new since 10.3+ JSON API uses the same controller for uploading as Core
+  // Which means filetypes are being checked (before it was the tmp controller)
+  // @see https://www.drupal.org/node/3445266. So we add empty file_extensions settings
   $fields['field_file_drop'] = BaseFieldDefinition::create('entity_reference')
     ->setName('field_file_drop')
     ->setLabel(t('Drop Files'))
@@ -206,6 +209,7 @@ function strawberryfield_entity_base_field_info(EntityTypeInterface $entity_type
         'target_type' => 'file',
         'file_directory' => 'sbf_tmp',
         'uri_scheme' => $schema,
+        'file_extensions' => ''
       ]
     )
     ->setClass(StrawberryFieldFileComputedItemList::class)


### PR DESCRIPTION
See #352 and #353 for more info. Specially needed if moving to Drupal 10.3+ without updating (at least partially) to Archipelago 1.5.0. This is 10.2 compatible of course

The main issue on 10.4 (tested here, never seen before) is that at the hook_entity_base_field_info() the stream wrapper manager no longer has the "names" for wrappers registered? Of maybe on a local? is using the wrong bits.

JSON API wise, we had to add 'file_extensions' => '' to the field settings, given that 10.3+ JSON API uses the core/standard file controller upload, when before it used to implement a wrapper for the temp file controller (which had no file restrictions).
