### PR TITLE
ISSUE-369: Drupal 10 version (Drupal 11 uses Hook annotations instead)

### DIFF
--- a/src/Field/StrawberryFieldEntityComputedSemanticTypeItemList.php
+++ b/src/Field/StrawberryFieldEntityComputedSemanticTypeItemList.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\strawberryfield\Field;
+
+use Drupal\Core\TypedData\ComputedItemListTrait;
+use Drupal\Core\Field\FieldItemList;
+class StrawberryFieldEntityComputedSemanticTypeItemList extends FieldItemList {
+
+
+  use ComputedItemListTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function computeValue() {
+    $this->ensurePopulated();
+  }
+
+  /**
+   * Computes the calculated values for this item list.
+   *
+   * In this example, there is only a single item/delta for this field.
+   *
+   * The ComputedItemListTrait only calls this once on the same instance; from
+   * then on, the value is automatically cached in $this->items, for use by
+   * methods like getValue().
+   */
+  protected function ensurePopulated() {
+    if (!isset($this->list[0])) {
+      $sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($this->getEntity());
+      foreach ($sbf_fields as $field_name) {
+        /** @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+        $field = $this->getEntity()->get($field_name);
+        if (!$field->isEmpty()) {
+          foreach ($field->getIterator() as $itemfield) {
+            // Note: we are not longer touching the metadata here.
+            /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $itemfield */
+            $flatvalues = (array) $itemfield->provideFlatten();
+            // @TODO use future flatversion precomputed at field level as a property
+            $json_error = json_last_error();
+            $sbf_type = [];
+            if (isset($flatvalues['type'])) {
+              $sbf_type = (array) $flatvalues['type'];
+              $sbf_type = array_filter($sbf_type, 'is_string');
+            }
+
+
+              foreach ($sbf_type as $delta => $type) {
+                $this->list[$delta] = $this->createItem($delta,$type );
+              }
+            }
+          }
+        }
+      }
+
+  }
+}

--- a/src/StrawberryFieldBreadcrumbBuilder.php
+++ b/src/StrawberryFieldBreadcrumbBuilder.php
@@ -254,13 +254,13 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
             $trail[$newpath] = array_slice($oldpath, 0, ($old_depth - 1), TRUE);
             $trail[$newpath]["{$referencedEntity->id()}"] = $referencedEntity->label();
 
-            $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail,$depth, $newpath, $bubbleableMetadata);
+            $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail,$depth, $newpath, $predicates, $ado_type, $bubbleableMetadata);
             $seen[] = $referencedEntity->id();
           }
         }
         else {
           $trail[$current_path]["{$referencedEntity->id()}"] = $referencedEntity->label();
-          $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail, $depth, $current_path, $bubbleableMetadata);
+          $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail, $depth, $current_path, $predicates, $ado_type, $bubbleableMetadata);
           $seen[]  = $referencedEntity->id();
         }
         $i++;

--- a/src/StrawberryFieldBreadcrumbBuilder.php
+++ b/src/StrawberryFieldBreadcrumbBuilder.php
@@ -11,6 +11,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Render\BubbleableMetadata;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -79,7 +80,7 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $entity = $route_match->getParameter('node');
     $qualifies = $route_match->getRouteName() == "entity.node.canonical" && $entity instanceof NodeInterface && $this->strawberryfieldUtility->bearsStrawberryfield($entity);
     if ($qualifies) {
-        return $this->configFactory->get('strawberryfield.breadcrumbs')->get('enabled');
+      return $this->configFactory->get('strawberryfield.breadcrumbs')->get('enabled');
     }
     return FALSE;
   }
@@ -173,11 +174,11 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
   }
 
   /**
-  * Best Longest Trail by comparing common Node IDs with the shorter ones.
+   * Best Longest Trail by comparing common Node IDs with the shorter ones.
    *
    *  @param array $trail_flat
    *   A list of Trails
-  */
+   */
   protected function smartTrail(array $trail_flat) {
 
     if (count($trail_flat) == 0) {
@@ -210,4 +211,62 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $key = $max[0] ?? NULL;
     return !empty($key) && isset($trail_flat[$key]) ? $trail_flat[$key] :  $longest_trail;
   }
+
+  /**
+   * Public method/builds Multiple Flat trails recursively filtered by predicate/ado type.
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $node
+   *   A  Node
+   * @param array $trail
+   *   All Trails keyed by a randon hash.
+   * @param int $depth
+   *  Current Depth of the recursive function
+   * @param string $current_path
+   *  The current Forked/flat Path (Key)
+   * @param array $predicates
+   * @param array $ado_type
+   * @param \Drupal\Core\Render\BubbleableMetadata $bubbleableMetadata
+   *
+   * @throws \Exception
+   */
+  public function recursiveParentPathsByTypeAndPredicate(EntityInterface $node, array &$trail, int $depth, string $current_path, array $predicates, array $ado_type, BubbleableMetadata $bubbleableMetadata) {
+    if ($depth >= 5) { return; }
+    // Everytime we diverge/multiple parents (like in git) we need to create a
+    // new Path ID/array that includes the previous one
+    // The idea is that this way we create multiple/overlapping paths/breacrumbs.
+    $old_depth = $depth;
+    $depth++;
+    $i = 0;
+    $seen = [];
+
+    foreach($this->strawberryfieldUtility->getStrawberryfieldParentADOs($node) as $predicate => $referencedEntitys) {
+
+      foreach ($referencedEntitys as $nid => $referencedEntity) {
+        $access = $referencedEntity->access('view', $this->account, TRUE);
+        $bubbleableMetadata->addCacheableDependency($access);
+        if ($access->isAllowed()) {
+          $bubbleableMetadata->addCacheableDependency($referencedEntity);
+        }
+        if ($i > 0) {
+          if (!in_array($referencedEntity->id(), $seen)){
+            $newpath = bin2hex(random_bytes(16));
+            $oldpath = $trail[$current_path];
+            $trail[$newpath] = array_slice($oldpath, 0, ($old_depth - 1), TRUE);
+            $trail[$newpath]["{$referencedEntity->id()}"] = $referencedEntity->label();
+
+            $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail,$depth, $newpath, $bubbleableMetadata);
+            $seen[] = $referencedEntity->id();
+          }
+        }
+        else {
+          $trail[$current_path]["{$referencedEntity->id()}"] = $referencedEntity->label();
+          $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail, $depth, $current_path, $bubbleableMetadata);
+          $seen[]  = $referencedEntity->id();
+        }
+        $i++;
+      }
+    }
+
+  }
+
 }

--- a/src/StrawberryFieldBreadcrumbBuilder.php
+++ b/src/StrawberryFieldBreadcrumbBuilder.php
@@ -219,17 +219,23 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
    *   A  Node
    * @param array $trail
    *   All Trails keyed by a randon hash.
+   *   Ommitted ADOs (bc of filters) in a TRAIL have a value of FALSE instead
+   *   of the Label.
    * @param int $depth
    *  Current Depth of the recursive function
    * @param string $current_path
    *  The current Forked/flat Path (Key)
    * @param array $predicates
-   * @param array $ado_type
+   *  Indexed list of JSON keys holding ADO to ADO relationships.["ismemberof"]
+   *  Leave empty if all properties should be accumulated
+   * @param array $ado_types
+   *  Indexed list of valid ADO semantic Types. e.g ["Collection"]
+   *  Leave empty if all types of ADOs should be accumulated
    * @param \Drupal\Core\Render\BubbleableMetadata $bubbleableMetadata
    *
    * @throws \Exception
    */
-  public function recursiveParentPathsByTypeAndPredicate(EntityInterface $node, array &$trail, int $depth, string $current_path, array $predicates, array $ado_type, BubbleableMetadata $bubbleableMetadata) {
+  public function recursiveParentPathsByTypeAndPredicate(EntityInterface $node, array &$trail, int $depth, string $current_path, array $predicates, array $ado_types, BubbleableMetadata $bubbleableMetadata) {
     if ($depth >= 5) { return; }
     // Everytime we diverge/multiple parents (like in git) we need to create a
     // new Path ID/array that includes the previous one
@@ -238,38 +244,76 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $depth++;
     $i = 0;
     $seen = [];
+    if (!empty($ado_types)) {
+      $ado_types = array_map(function ($el) {
+        $value = is_string($el) ? strtolower($el) : NULL;
+        return $value;
+      }, $ado_types);
+      $ado_types = array_filter($ado_types);
+    }
+
+    if (!empty($predicates)) {
+      $predicates = array_map(function ($el) {
+        $value = is_string($el) ? strtolower($el) : NULL;
+        return $value;
+      }, $predicates);
+      $predicates = array_filter($predicates);
+    }
     // Note: Filtering by Type && Property does not mean
     // not traversing the paths. Just means not accumulating Labels
     // The goal here is to allow someone to get e.g Just parent Collections
     // even if the object is nested by a CWS and an isParent.
     foreach($this->strawberryfieldUtility->getStrawberryfieldParentADOs($node) as $predicate => $referencedEntitys) {
-
       foreach ($referencedEntitys as $nid => $referencedEntity) {
         $access = $referencedEntity->access('view', $this->account, TRUE);
         $bubbleableMetadata->addCacheableDependency($access);
         if ($access->isAllowed()) {
           $bubbleableMetadata->addCacheableDependency($referencedEntity);
         }
-        if ($i > 0) {
+        if ($i == 1) {
+          // Any other loop
           if (!in_array($referencedEntity->id(), $seen)){
             $newpath = bin2hex(random_bytes(16));
             $oldpath = $trail[$current_path];
             $trail[$newpath] = array_slice($oldpath, 0, ($old_depth - 1), TRUE);
-            $trail[$newpath]["{$referencedEntity->id()}"] = $referencedEntity->label();
-
-            $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail,$depth, $newpath, $predicates, $ado_type, $bubbleableMetadata);
+            // Fill skippped paths with FALSE; Only way the "dept" can be kept and used for slicing.
+            $trail[$newpath]["{$referencedEntity->id()}"] =  $this->shouldTrackCrumb($referencedEntity, $predicate, $predicates, $ado_types) ? $referencedEntity->label() : FALSE;
             $seen[] = $referencedEntity->id();
+            $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail, $depth, $newpath, $predicates, $ado_types, $bubbleableMetadata);
           }
         }
         else {
-          $trail[$current_path]["{$referencedEntity->id()}"] = $referencedEntity->label();
-          $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail, $depth, $current_path, $predicates, $ado_type, $bubbleableMetadata);
-          $seen[]  = $referencedEntity->id();
+            $seen[] = $referencedEntity->id();
+            // Fill skippped paths with FALSE;
+            $trail[$current_path]["{$referencedEntity->id()}"] = $this->shouldTrackCrumb($referencedEntity, $predicate, $predicates, $ado_types) ? $referencedEntity->label() : FALSE;
+            $i = 1;
+          $this->recursiveParentPathsByTypeAndPredicate($referencedEntity, $trail, $depth, $current_path, $predicates, $ado_types, $bubbleableMetadata);
         }
-        $i++;
       }
     }
-
   }
 
+
+  private function shouldTrackCrumb(EntityInterface $node, $holding_predicate, $predicates, $ado_types) {
+    $should_track = TRUE;
+    $in_type = TRUE;
+    if (empty($predicates) || in_array($holding_predicate, $predicates)) {
+      // Only accumulate and mark as seen if we have no restrictions
+      if (!empty($ado_types) && $node->hasField('field_sbf_semantictype')) {
+        $types = $node->get('field_sbf_semantictype')->getValue();
+        if (is_array($types) && count($types)) {
+          $sbf_type = [];
+          foreach ($types as $type) {
+            $sbf_type[] = is_string($type['value'] ?? NULL) ? strtolower($type['value']) : NULL;
+          }
+          $in_type = array_intersect($sbf_type, $ado_types);
+          $in_type = count($in_type) ? TRUE : FALSE;
+        }
+      }
+      if (!$in_type) {
+        $should_track = FALSE;
+      }
+    }
+    return $should_track;
+  }
 }

--- a/src/StrawberryFieldBreadcrumbBuilder.php
+++ b/src/StrawberryFieldBreadcrumbBuilder.php
@@ -238,7 +238,10 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
     $depth++;
     $i = 0;
     $seen = [];
-
+    // Note: Filtering by Type && Property does not mean
+    // not traversing the paths. Just means not accumulating Labels
+    // The goal here is to allow someone to get e.g Just parent Collections
+    // even if the object is nested by a CWS and an isParent.
     foreach($this->strawberryfieldUtility->getStrawberryfieldParentADOs($node) as $predicate => $referencedEntitys) {
 
       foreach ($referencedEntitys as $nid => $referencedEntity) {

--- a/src/StrawberryFieldBreadcrumbBuilder.php
+++ b/src/StrawberryFieldBreadcrumbBuilder.php
@@ -295,9 +295,10 @@ class StrawberryFieldBreadcrumbBuilder implements BreadcrumbBuilderInterface {
 
 
   private function shouldTrackCrumb(EntityInterface $node, $holding_predicate, $predicates, $ado_types) {
-    $should_track = TRUE;
+    $should_track = FALSE;
     $in_type = TRUE;
     if (empty($predicates) || in_array($holding_predicate, $predicates)) {
+      $should_track = TRUE;
       // Only accumulate and mark as seen if we have no restrictions
       if (!empty($ado_types) && $node->hasField('field_sbf_semantictype')) {
         $types = $node->get('field_sbf_semantictype')->getValue();

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -192,7 +192,10 @@ class StrawberryfieldUtilityService implements StrawberryfieldUtilityServiceInte
           // predicate
           if (isset($flatvalues['dr:nid']) && !empty($flatvalues['dr:nid'])) {
             $entity_ids = (array) $flatvalues['dr:nid'];
-            $node_entities = array_filter($entity_ids, 'is_integer');
+            $node_entities = array_filter($entity_ids, function ($el) {
+              $el = filter_var($el, FILTER_VALIDATE_INT);
+              return $el;
+            });
             if (count($node_entities)) {
               $node_entities['nids']['dr:nid'] = $node_entities;
             }
@@ -207,7 +210,10 @@ class StrawberryfieldUtilityService implements StrawberryfieldUtilityServiceInte
                   $entity_ids = (array) $values[$jsonkey_with_node_entity];
                   // We filter for scalar that way we don't end sending an array or object to UUid validator.
                   $entity_ids = array_filter($entity_ids, 'is_scalar');
-                  $node_entities_ids = array_filter($entity_ids, 'is_integer');
+                  $node_entities_ids = array_filter($entity_ids, function ($el) {
+                    $el = filter_var($el, FILTER_VALIDATE_INT);
+                    return $el;
+                  });
                   $node_entities_uuids = array_filter($entity_ids, [
                     '\Ramsey\Uuid\Uuid',
                     'isValid'

--- a/src/StrawberryfieldUtilityService.php
+++ b/src/StrawberryfieldUtilityService.php
@@ -24,6 +24,7 @@ use Drupal\search_api\ParseMode\ParseModePluginManager;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\strawberryfield\Plugin\search_api\datasource\StrawberryfieldFlavorDatasource;
 use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
+use Ramsey\Uuid\Uuid;
 use SplFileObject;
 
 /**
@@ -161,6 +162,104 @@ class StrawberryfieldUtilityService implements StrawberryfieldUtilityServiceInte
       }
     }
     return $hassbf[$key];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getStrawberryfieldParentADOs(ContentEntityInterface $entity) {
+
+    $sbf_fields = $this->bearsStrawberryfield($entity);
+
+    $node_entities['nids'] = [];
+    $node_entities['uuids'] = [];
+    $node_entities_by_predicate = [];
+
+    foreach ($sbf_fields as $field_name) {
+      /* @var $field \Drupal\Core\Field\FieldItemInterface */
+      $field = $entity->get($field_name);
+      $node_entities = [];
+      if (!$field->isEmpty()) {
+        foreach ($field->getIterator() as $delta => $itemfield) {
+          // Note: we are not longer touching the metadata here.
+          /** @var $itemfield \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem */
+          $flatvalues = (array) $itemfield->provideFlatten();
+          $values = (array) $itemfield->provideDecoded();
+          // This is just for semantic consistency since we DO allow
+          // dr:fid.
+          // only try to fetch these if we are not asking for a predicate
+          //  dr:fid is not in use in production, but if found will be a generic
+          // predicate
+          if (isset($flatvalues['dr:nid']) && !empty($flatvalues['dr:nid'])) {
+            $entity_ids = (array) $flatvalues['dr:nid'];
+            $node_entities = array_filter($entity_ids, 'is_integer');
+            if (count($node_entities)) {
+              $node_entities['nids']['dr:nid'] = $node_entities;
+            }
+          }
+          // Get mapped ones
+          if (isset($values["ap:entitymapping"]["entity:node"]) &&
+            !empty($values["ap:entitymapping"]["entity:node"])) {
+            $jsonkeys_with_node_entities = (array) $values["ap:entitymapping"]["entity:node"];
+            foreach ($jsonkeys_with_node_entities as $jsonkey_with_node_entity) {
+              if (is_string($jsonkey_with_node_entity)) {
+                if (isset($values[$jsonkey_with_node_entity]) && !empty($values[$jsonkey_with_node_entity])) {
+                  $entity_ids = (array) $values[$jsonkey_with_node_entity];
+                  // We filter for scalar that way we don't end sending an array or object to UUid validator.
+                  $entity_ids = array_filter($entity_ids, 'is_scalar');
+                  $node_entities_ids = array_filter($entity_ids, 'is_integer');
+                  $node_entities_uuids = array_filter($entity_ids, [
+                    '\Ramsey\Uuid\Uuid',
+                    'isValid'
+                  ]);
+                  $node_entities['nids'][$jsonkey_with_node_entity] = array_merge($node_entities['nids'][$jsonkey_with_node_entity] ?? [], $node_entities_ids);
+                  $node_entities['uuids'][$jsonkey_with_node_entity] = array_merge($node_entities['uuids'][$jsonkey_with_node_entity] ?? [], $node_entities_uuids);
+                }
+              }
+            }
+          }
+        }
+      }
+      // Now see if we can load the Node entities
+      // If the user repeats the ADOs, then we will load multiple times
+      // This is less optimal than loading All IDs
+      // Then all UUIDs
+      // And then distributing based on source
+      // But it is easier to read.
+      try {
+        if (is_array($node_entities['uuids'] ?? NULL)) {
+          foreach ($node_entities['uuids'] as $predicate => $nodelist) {
+            if (is_array($nodelist) && !empty($nodelist)) {
+              $ados_from_uuid = $this->entityTypeManager->getStorage('node')
+                ->loadByProperties(['uuid' => $nodelist]);
+              if (count($ados_from_uuid)) {
+                $node_entities_by_predicate[$predicate] = $ados_from_uuid;
+              }
+            }
+          }
+        }
+        if (is_array($node_entities['nids'] ?? NULL)) {
+          foreach ($node_entities['nids'] as $predicate => $nodelist) {
+            // We can remove here by key, $node_entities_by_predicate[$predicate] will have NODE_ID as indexes
+            // To avoid duplicates
+            $loaded_node_ids = array_keys($node_entities_by_predicate[$predicate] ?? []);
+            $not_loaded_yet_is = array_diff($nodelist, $loaded_node_ids);
+            if (is_array($not_loaded_yet_is) && !empty($not_loaded_yet_is)) {
+              $ados_from_id = $this->entityTypeManager->getStorage('node')
+                ->loadMultiple($not_loaded_yet_is);
+              if (count($ados_from_id)) {
+                $node_entities_by_predicate[$predicate] = ($node_entities_by_predicate[$predicate] ?? []) + $ados_from_id;
+              }
+            }
+          }
+        }
+      }
+      catch (\Throwable) {
+        $this->loggerFactory->get('strawberryfield')->error($this->t('Error while computing parent ADOs for Node ID @nid', ['@nid' => $entity->id()]));
+        $node_entities_by_predicate = [];
+      }
+    }
+    return $node_entities_by_predicate;
   }
 
   /**

--- a/src/StrawberryfieldUtilityServiceInterface.php
+++ b/src/StrawberryfieldUtilityServiceInterface.php
@@ -27,6 +27,21 @@ interface StrawberryfieldUtilityServiceInterface {
   public function bearsStrawberryfield(ContentEntityInterface $entity);
 
   /**
+   * Provides Parent ADOs found in an Content entity bearing SBF
+   *
+   * This is computed directly from the JSON.
+   * Returned ADOs are grouped by the predicate they were found in.
+   * Computes Node ID (integer) and UUIDs.
+   *
+   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
+   *
+   * @return array
+   *  Returns an associative array of Preloaded Nodes or an empty array if none
+   *  found.
+   */
+  public function getStrawberryfieldParentADOs(ContentEntityInterface $entity);
+
+  /**
    * Returns a list of the machine names of all existing SBF fields
    *
    * @return array

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -24,6 +24,7 @@ use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\node\NodeInterface;
+use Drupal\Core\Render\BubbleableMetadata;
 
 
 /**
@@ -375,8 +376,142 @@ function strawberryfield_entity_view_alter(array &$build, EntityInterface $entit
 }
 
 /**
-* Implements hook_element_info_alter().
+ * Implements hook_element_info_alter().
  */
 function strawberryfield_element_info_alter(array &$info): void {
   array_unshift($info['view']['#pre_render'], 'Drupal\strawberryfield\StrawberryfieldRenderCallbacks::preRender');
+}
+
+/**
+ * Implements hook_token_info().
+ */
+function strawberryfield_token_info() {
+  $types['ado'] = [
+    'name' => t('Archipelago Digital Object'),
+    'description' => t('Defines custom tokens for Strawberryfield Bearing Nodes (ADOs).'),
+    'needs-data' => 'node'
+  ];
+  $tokens['type'] = [
+    'name' => t('ADO Type'),
+    'description' => t('Token to get the main JSON type of an ADO.'),
+  ];
+  $tokens['types'] = [
+    'name' => t('ADO Types'),
+    'description' => t('Token to get all JSON types (flattened type key at any hierarchy) of an ADO.'),
+    'type' => 'array',
+  ];
+
+  $tokens['breadcrumps'] = [
+    'name' => t('All Breadcrumb'),
+    'description' => t('Token to get all JSON types (flattened type key at any hierarchy) of an ADO.'),
+    'type' => 'array',
+  ];
+  $tokens['breadcrump_by_ado_type'] = [
+    'name' => t('ADO Parentship breadcrumb filtered by ADO type'),
+    'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but filtering out any ADO type that is not provided'),
+    'dynamic' => TRUE,
+    'type' => 'array',
+  ];
+  $tokens['breadcrumps_by_relation'] = [
+    'name' => t('ADO Parentship breadcrumb filtered by connecting relationship'),
+    'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but for specific relationships (e.g ismemberof)'),
+    'dynamic' => TRUE,
+    'type' => 'array',
+  ];
+  return [
+    'types' => $types,
+    'tokens' => ['ado' => $tokens],
+  ];
+}
+
+/**
+ * Implements hook_tokens().
+ */
+function strawberryfield_tokens($type, array $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+  $token_service = \Drupal::token();
+  if ($type === 'ado' && !empty($data['node'])) {
+    /** @var \Drupal\webform\WebformSubmissionInterface $webform_submission */
+    $node = $data['node'];
+    $sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($node);
+
+    if (empty($sbf_fields)) {
+      return $replacements;
+    }
+    $parents = \Drupal::service('strawberryfield.utility')->getStrawberryfieldParentADOs($node);
+    $trail = [];
+    $start_path = bin2hex(random_bytes(16));
+    $paths =  \Drupal::service('strawberryfield.semantic_breadcrumb')->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, $bubbleable_metadata);
+
+    foreach ($sbf_fields as $field_name) {
+      /* @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $field */
+      $field = $node->get($field_name);
+      if (!$field->isEmpty()) {
+        foreach ($field->getIterator() as $delta => $itemfield) {
+          /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $itemfield */
+          /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
+          // This will try with any possible match.
+          $jsondata = json_decode($itemfield->value, TRUE);
+          $flatvalues = (array) $itemfield->provideFlatten();
+          // @TODO use future flatversion precomputed at field level as a property
+          $json_error = json_last_error();
+          if ($json_error == JSON_ERROR_NONE) {
+            foreach ($tokens as $name => $original) {
+              switch ($name) {
+                case 'type':
+                  // If for some reason a SBF is multivalued, we return any
+                  // previously set *(first one only)
+                  if (empty($replacements[$original])) {
+                    $type = $jsondata['type'] ?? NULL;
+                    if (is_array($type) ) {
+                      $type = reset($type);
+                    }
+                    $type = is_string($type) ? $type : NULL;
+                    if ($type) {
+                      $replacements[$original] = $type;
+                    }
+                  }
+                  break;
+                case 'types':
+                  // If for some reason a SBF is multivalued, we return any
+                  // previously set *(first one only)
+                  // Run first on entity:files
+                  $sbf_type = [];
+                  if (isset($flatvalues['type'])) {
+                    $sbf_type = (array) $flatvalues['type'];
+                    $sbf_type = array_filter($sbf_type, 'is_string');
+                  }
+                  // if called without chainging return the first string?
+                  $replacements[$original] = array_merge(($replacements[$original] ?? []), $sbf_type);
+                  $replacements[$original] = array_unique($replacements[$original]);
+                  $replacements[$original] = reset( $replacements[$original]);
+                  break;
+              }
+            }
+
+          // For chaining.
+            if ($types_tokens = $token_service->findWithPrefix($tokens, 'types')) {
+              // Run first on entity:files
+              $sbf_type = [];
+              if (isset($flatvalues['type'])) {
+                $sbf_type = (array) $flatvalues['type'];
+                $sbf_type = array_filter($sbf_type, 'is_string');
+              }
+              $replacements += $token_service->generate('array', $types_tokens, ['array' => $sbf_type], $options, $bubbleable_metadata);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /*if ($types_tokens = $token_service->findWithPrefix($tokens, 'types')) {
+    $replacements += $token_service->generate('array', $tokens, ['array' => ['ml','js']], $options, $bubbleable_metadata);
+  }*/
+
+  /*if ($entity_tokens = $token_service->findWithPrefix($tokens, 'node')) {
+    $replacements += $token_service->generate('node', $entity_tokens, ['node' => $source_entity], $options, $bubbleable_metadata);
+  }*/
+return $replacements;
+
 }

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -444,9 +444,15 @@ function strawberryfield_token_info() {
     'dynamic' => TRUE,
     'type' => 'array',
   ];
+  // Also create an ADO wrapper inside node
+  $token_ado['ado'] = [
+    'name' => t('ADO'),
+    'description' => t('Wrapper on the Node Token so we can call the other tokens when modules only call Core ones'),
+    'dynamic' => TRUE,
+  ] ;
   return [
     'types' => $types,
-    'tokens' => ['ado' => $tokens],
+    'tokens' => ['ado' => $tokens, 'node' => $token_ado],
   ];
 }
 
@@ -456,6 +462,16 @@ function strawberryfield_token_info() {
 function strawberryfield_tokens($type, array $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
   $replacements = [];
   $token_service = \Drupal::token();
+  // First check for a Top node:ado... then chain
+  if ($type === 'node' && !empty($data['node'])) {
+    if ($ado_from_node = $token_service->findWithPrefix($tokens, 'ado')) {
+      foreach ($ado_from_node as $passed_from_node => $original) {
+        $token_to_call = [$passed_from_node => $original];
+        $replacements += $token_service->generate('ado', $token_to_call, $data, $options, $bubbleable_metadata);
+      }
+    }
+  }
+
   if ($type === 'ado' && !empty($data['node'])) {
     /** @var \Drupal\webform\WebformSubmissionInterface $webform_submission */
     $node = $data['node'];

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -465,7 +465,6 @@ function strawberryfield_tokens($type, array $tokens, array $data, array $option
     /** @var \Drupal\webform\WebformSubmissionInterface $webform_submission */
     $node = $data['node'];
     $sbf_fields = \Drupal::service('strawberryfield.utility')->bearsStrawberryfield($node);
-
     if (empty($sbf_fields)) {
       return $replacements;
     }
@@ -514,27 +513,39 @@ function strawberryfield_tokens($type, array $tokens, array $data, array $option
     if ($breadcrump_by_ado_type_tokens = $token_service->findWithPrefix($tokens, 'breadcrumb_by_ado_type')) {
       foreach($breadcrump_by_ado_type_tokens as $passed_type_with_suffix => $original) {
         $trail = [];
-        $parent_array = [];
+        // @TODO. this logic works when the token is called with an array operator
+        // but will fail if the user forgets.
         $ado_type = explode(":",$passed_type_with_suffix, 2);
 
         $start_path = bin2hex(random_bytes(16));
-        \Drupal::service('strawberryfield.semantic_breadcrumb')
-          ->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, [], [$ado_type[0] ?? NULL], $bubbleable_metadata);
-        // Now we can have multiple paths here.
-        // And bacause we are filtering each path might have FALSE entries (to keep the length/dept)
-        $array_for_token = [];
-        $longest = 0;
-        foreach ($trail as $randomkey => $apath) {
-          $apath = is_array($apath) ? array_filter($apath) : [];
-          if (!empty($apath)) {
-            if (count($apath) > $longest) {
-              $array_for_token = array_reverse($apath);
-              $longest =  count($apath);
+        try {
+          \Drupal::service('strawberryfield.semantic_breadcrumb')
+            ->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, [], [$ado_type[0] ?? NULL], $bubbleable_metadata);
+          // Now we can have multiple paths here.
+          // And because we are filtering each path might have FALSE entries (to keep the length/dept)
+          $array_for_token = [];
+          $longest = 0;
+          foreach ($trail as $randomkey => $apath) {
+            $apath = is_array($apath) ? array_filter($apath) : [];
+            if (!empty($apath)) {
+              if (count($apath) > $longest) {
+                $array_for_token = array_reverse($apath);
+                $longest =  count($apath);
+              }
             }
           }
+          $breadcrump_by_ado_type_token = [$ado_type[1] => $original];
+          $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $array_for_token], $options, $bubbleable_metadata);
         }
-        $breadcrump_by_ado_type_token = [$ado_type[1] => $original];
-        $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $array_for_token], $options, $bubbleable_metadata);
+        catch (\Throwable $e) {
+          \Drupal::logger('strawberryfield')->error(
+            'ADO with UUID @uuid failed parsing Token @token <br><ul>@events</ul>',
+            [
+              '@uuid' => $node->uuid(),
+              '@token' => $original
+            ]
+          );
+        }
       }
     }
 

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -519,12 +519,16 @@ function strawberryfield_tokens($type, array $tokens, array $data, array $option
 
         $start_path = bin2hex(random_bytes(16));
         \Drupal::service('strawberryfield.semantic_breadcrumb')
-          ->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, [$ado_type[0] ?? NULL], [], $bubbleable_metadata);
+          ->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, [], [$ado_type[0] ?? NULL], $bubbleable_metadata);
         $single_path = reset($trail);
-        $single_path = array_values($single_path);
+        if ($single_path !== FALSE) {
+          $single_path = array_values($single_path);
+        }
+        else {
+          $single_path = [];
+        }
         $breadcrump_by_ado_type_token = [$ado_type[1] => $original];
         $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $single_path], $options, $bubbleable_metadata);
-        //$replacements += $token_service->generate('array', $breadcrump_by_ado_type_tokens, ['array' => $single_path], $options, $bubbleable_metadata);
       }
     }
 

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -520,15 +520,21 @@ function strawberryfield_tokens($type, array $tokens, array $data, array $option
         $start_path = bin2hex(random_bytes(16));
         \Drupal::service('strawberryfield.semantic_breadcrumb')
           ->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, [], [$ado_type[0] ?? NULL], $bubbleable_metadata);
-        $single_path = reset($trail);
-        if ($single_path !== FALSE) {
-          $single_path = array_values($single_path);
-        }
-        else {
-          $single_path = [];
+        // Now we can have multiple paths here.
+        // And bacause we are filtering each path might have FALSE entries (to keep the length/dept)
+        $array_for_token = [];
+        $longest = 0;
+        foreach ($trail as $randomkey => $apath) {
+          $apath = is_array($apath) ? array_filter($apath) : [];
+          if (!empty($apath)) {
+            if (count($apath) > $longest) {
+              $array_for_token = array_reverse($apath);
+              $longest =  count($apath);
+            }
+          }
         }
         $breadcrump_by_ado_type_token = [$ado_type[1] => $original];
-        $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $single_path], $options, $bubbleable_metadata);
+        $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $array_for_token], $options, $bubbleable_metadata);
       }
     }
 

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -432,20 +432,15 @@ function strawberryfield_token_info() {
     'type' => 'array',
   ];
 
-  $tokens['breadcrumb'] = [
-    'name' => t('Semantic Breadcrumb'),
-    'description' => t('Token to get the ADO Semantic Breadcrumb as an Array using the same stragegy as configured for rendering.'),
-    'type' => 'array',
-  ];
   $tokens['breadcrumb_by_ado_type'] = [
     'name' => t('ADO Parentship breadcrumb filtered by ADO type'),
-    'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but filtering out any ADO type that is not provided'),
+    'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but filtering out any ADO type that is not provided. If multiple trails, the longest is returned'),
     'dynamic' => TRUE,
     'type' => 'array',
   ];
   $tokens['breadcrumb_by_relation'] = [
     'name' => t('ADO Parentship breadcrumb filtered by connecting relationship'),
-    'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but for specific relationships (e.g ismemberof)'),
+    'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but for specific relationships (e.g ismemberof). If multiple trails, the longest is returned'),
     'dynamic' => TRUE,
     'type' => 'array',
   ];
@@ -525,7 +520,7 @@ function strawberryfield_tokens($type, array $tokens, array $data, array $option
           // And because we are filtering each path might have FALSE entries (to keep the length/dept)
           $array_for_token = [];
           $longest = 0;
-          foreach ($trail as $randomkey => $apath) {
+          foreach ($trail as $apath) {
             $apath = is_array($apath) ? array_filter($apath) : [];
             if (!empty($apath)) {
               if (count($apath) > $longest) {
@@ -534,8 +529,64 @@ function strawberryfield_tokens($type, array $tokens, array $data, array $option
               }
             }
           }
-          $breadcrump_by_ado_type_token = [$ado_type[1] => $original];
-          $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $array_for_token], $options, $bubbleable_metadata);
+          if (isset($ado_type[1]) && strpos($ado_type[1], ":") !== FALSE) {
+            $breadcrump_by_ado_type_token = [$ado_type[1] => $original];
+            $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $array_for_token], $options, $bubbleable_metadata);
+          }
+          else {
+            // if just calling the actual token without any array processing, we return a string representation, the last one
+            $ado_label = end($array_for_token);
+            if ($ado_label) {
+              $replacements[$original] = $ado_label;
+              }
+          }
+        }
+        catch (\Throwable $e) {
+          \Drupal::logger('strawberryfield')->error(
+            'ADO with UUID @uuid failed parsing Token @token <br><ul>@events</ul>',
+            [
+              '@uuid' => $node->uuid(),
+              '@token' => $original
+            ]
+          );
+        }
+      }
+    }
+
+    if ($breadcrump_by_relationship_tokens = $token_service->findWithPrefix($tokens, 'breadcrumb_by_relation')) {
+      foreach($breadcrump_by_relationship_tokens as $passed_rel_with_suffix => $original) {
+        $trail = [];
+        // @TODO. this logic works when the token is called with an array operator
+        // but will fail if the user forgets.
+        $rel = explode(":", $passed_rel_with_suffix, 2);
+        $start_path = bin2hex(random_bytes(16));
+        try {
+          \Drupal::service('strawberryfield.semantic_breadcrumb')
+            ->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, [$rel[0] ?? NULL], [], $bubbleable_metadata);
+          // Now we can have multiple paths here.
+          // And because we are filtering each path might have FALSE entries (to keep the length/dept)
+          $array_for_token = [];
+          $longest = 0;
+          foreach ($trail as $apath) {
+            $apath = is_array($apath) ? array_filter($apath) : [];
+            if (!empty($apath)) {
+              if (count($apath) > $longest) {
+                $array_for_token = array_reverse($apath);
+                $longest =  count($apath);
+              }
+            }
+          }
+          if (isset($rel[1]) && strpos($rel[1], ":") !== FALSE) {
+            $breadcrump_by_rel_token = [$rel[1] => $original];
+            $replacements += $token_service->generate('array', $breadcrump_by_rel_token, ['array' => $array_for_token], $options, $bubbleable_metadata);
+          }
+          else {
+            // if just calling the actual token without any array processing, we return a string representation, the last one
+            $ado_label = end($array_for_token);
+            if ($ado_label) {
+              $replacements[$original] = $ado_label;
+            }
+          }
         }
         catch (\Throwable $e) {
           \Drupal::logger('strawberryfield')->error(

--- a/strawberryfield.module
+++ b/strawberryfield.module
@@ -16,6 +16,7 @@ use Drupal\Core\StreamWrapper\StreamWrapperInterface;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\strawberryfield\Field\StrawberryFieldFileComputedItemList;
 use Drupal\strawberryfield\Field\StrawberryFieldEntityComputedItemList;
+use  Drupal\strawberryfield\Field\StrawberryFieldEntityComputedSemanticTypeItemList;
 use Drupal\strawberryfield\StrawberryfieldRenderCallbacks;
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Field\FieldDefinitionInterface;
@@ -231,6 +232,19 @@ function strawberryfield_entity_base_field_info(EntityTypeInterface $entity_type
     ->setTranslatable(FALSE)
     ->setClass(StrawberryFieldEntityComputedItemList::class);
 
+  $fields['field_sbf_semantictype'] = BaseFieldDefinition::create('string')
+    ->setName('field_sbf_semantictype')
+    ->setLabel('ADOs semantic type ("type" json key)')
+    ->setDescription(t('Computed "type" key value from the RAW JSON as a single string'))
+    ->setCardinality(FieldStorageDefinitionInterface::CARDINALITY_UNLIMITED)
+    ->setComputed(TRUE)
+    ->setRevisionable(FALSE)
+    ->setReadOnly(TRUE)
+    ->setTranslatable(FALSE)
+    ->setClass(\Drupal\strawberryfield\Field\StrawberryFieldEntityComputedSemanticTypeItemList::class)
+    ->setDisplayConfigurable('view', FALSE)
+    ->setDisplayConfigurable('form', FALSE);
+
   return $fields;
 }
 
@@ -268,6 +282,23 @@ function strawberryfield_entity_bundle_field_info(EntityTypeInterface $entity_ty
       $base_field_definitions['field_sbf_nodetonode']->setTargetBundle($bundle);
       return [
         'field_sbf_nodetonode' => $base_field_definitions['field_sbf_nodetonode'],
+      ];
+    }
+  }
+
+
+  if (($entity_type->id() == 'node') && isset($base_field_definitions['field_sbf_semantictype'])) {
+    if (\Drupal::service('strawberryfield.utility')
+      ->bundleHasStrawberryfield($bundle)) {
+
+      // Add the target bundle to the field_file_drop base field
+      // only if it carries a Strawberryfield
+      // In practice this will allow Bundle specific create access permissions
+      // to work and force anything not Strawberryfield to either have the node
+      // access override or simply not work.
+      $base_field_definitions['field_sbf_semantictype']->setTargetBundle($bundle);
+      return [
+        'field_sbf_semantictype' => $base_field_definitions['field_sbf_semantictype'],
       ];
     }
   }
@@ -401,18 +432,18 @@ function strawberryfield_token_info() {
     'type' => 'array',
   ];
 
-  $tokens['breadcrumps'] = [
-    'name' => t('All Breadcrumb'),
-    'description' => t('Token to get all JSON types (flattened type key at any hierarchy) of an ADO.'),
+  $tokens['breadcrumb'] = [
+    'name' => t('Semantic Breadcrumb'),
+    'description' => t('Token to get the ADO Semantic Breadcrumb as an Array using the same stragegy as configured for rendering.'),
     'type' => 'array',
   ];
-  $tokens['breadcrump_by_ado_type'] = [
+  $tokens['breadcrumb_by_ado_type'] = [
     'name' => t('ADO Parentship breadcrumb filtered by ADO type'),
     'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but filtering out any ADO type that is not provided'),
     'dynamic' => TRUE,
     'type' => 'array',
   ];
-  $tokens['breadcrumps_by_relation'] = [
+  $tokens['breadcrumb_by_relation'] = [
     'name' => t('ADO Parentship breadcrumb filtered by connecting relationship'),
     'description' => t('Token to get the complete parent (ADO to ADO) breadcrump, but for specific relationships (e.g ismemberof)'),
     'dynamic' => TRUE,
@@ -438,80 +469,70 @@ function strawberryfield_tokens($type, array $tokens, array $data, array $option
     if (empty($sbf_fields)) {
       return $replacements;
     }
-    $parents = \Drupal::service('strawberryfield.utility')->getStrawberryfieldParentADOs($node);
-    $trail = [];
-    $start_path = bin2hex(random_bytes(16));
-    $paths =  \Drupal::service('strawberryfield.semantic_breadcrumb')->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, $bubbleable_metadata);
 
-    foreach ($sbf_fields as $field_name) {
-      /* @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $field */
-      $field = $node->get($field_name);
-      if (!$field->isEmpty()) {
-        foreach ($field->getIterator() as $delta => $itemfield) {
-          /** @var \Drupal\strawberryfield\Plugin\Field\FieldType\StrawberryFieldItem $itemfield */
-          /* @var \Drupal\strawberryfield\Field\StrawberryFieldItemList $field */
-          // This will try with any possible match.
-          $jsondata = json_decode($itemfield->value, TRUE);
-          $flatvalues = (array) $itemfield->provideFlatten();
-          // @TODO use future flatversion precomputed at field level as a property
-          $json_error = json_last_error();
-          if ($json_error == JSON_ERROR_NONE) {
-            foreach ($tokens as $name => $original) {
-              switch ($name) {
-                case 'type':
-                  // If for some reason a SBF is multivalued, we return any
-                  // previously set *(first one only)
-                  if (empty($replacements[$original])) {
-                    $type = $jsondata['type'] ?? NULL;
-                    if (is_array($type) ) {
-                      $type = reset($type);
-                    }
-                    $type = is_string($type) ? $type : NULL;
-                    if ($type) {
-                      $replacements[$original] = $type;
-                    }
-                  }
-                  break;
-                case 'types':
-                  // If for some reason a SBF is multivalued, we return any
-                  // previously set *(first one only)
-                  // Run first on entity:files
-                  $sbf_type = [];
-                  if (isset($flatvalues['type'])) {
-                    $sbf_type = (array) $flatvalues['type'];
-                    $sbf_type = array_filter($sbf_type, 'is_string');
-                  }
-                  // if called without chainging return the first string?
-                  $replacements[$original] = array_merge(($replacements[$original] ?? []), $sbf_type);
-                  $replacements[$original] = array_unique($replacements[$original]);
-                  $replacements[$original] = reset( $replacements[$original]);
-                  break;
-              }
-            }
-
-          // For chaining.
-            if ($types_tokens = $token_service->findWithPrefix($tokens, 'types')) {
-              // Run first on entity:files
-              $sbf_type = [];
-              if (isset($flatvalues['type'])) {
-                $sbf_type = (array) $flatvalues['type'];
-                $sbf_type = array_filter($sbf_type, 'is_string');
-              }
-              $replacements += $token_service->generate('array', $types_tokens, ['array' => $sbf_type], $options, $bubbleable_metadata);
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'type':
+          if ($node->hasField('field_sbf_semantictype')) {
+            $types = $node->get('field_sbf_semantictype')->getValue();
+            if (is_array($types) && count($types)) {
+              $type =  reset($types);
+              $sbf_type = $type['value'] ?? '';
+              $replacements[$original] = $sbf_type;
             }
           }
+          break;
+        case 'types':
+          if ($node->hasField('field_sbf_semantictype')) {
+            $types = $node->get('field_sbf_semantictype')->getValue();
+            if (is_array($types) && count($types)) {
+              $sbf_type = [];
+              foreach($types as $type) {
+                $sbf_type[] = $type['value'] ?? NULL;
+              }
+              $replacements[$original] = $sbf_type;
+            }
+          }
+          break;
+      }
+    }
+
+    // For chaining "types" into an array.
+    if ($types_tokens = $token_service->findWithPrefix($tokens, 'types')) {
+      if ($node->hasField('field_sbf_semantictype')) {
+        $types = $node->get('field_sbf_semantictype')->getValue();
+        if (is_array($types) && count($types)) {
+          $sbf_type = [];
+          foreach ($types as $type) {
+            $sbf_type[] = $type['value'] ?? NULL;
+          }
+          $replacements += $token_service->generate('array', $types_tokens, ['array' => $sbf_type], $options, $bubbleable_metadata);
         }
       }
     }
+
+    if ($breadcrump_by_ado_type_tokens = $token_service->findWithPrefix($tokens, 'breadcrumb_by_ado_type')) {
+      foreach($breadcrump_by_ado_type_tokens as $passed_type_with_suffix => $original) {
+        $trail = [];
+        $parent_array = [];
+        $ado_type = explode(":",$passed_type_with_suffix, 2);
+
+        $start_path = bin2hex(random_bytes(16));
+        \Drupal::service('strawberryfield.semantic_breadcrumb')
+          ->recursiveParentPathsByTypeAndPredicate($node, $trail, 1, $start_path, [$ado_type[0] ?? NULL], [], $bubbleable_metadata);
+        $single_path = reset($trail);
+        $single_path = array_values($single_path);
+        $breadcrump_by_ado_type_token = [$ado_type[1] => $original];
+        $replacements += $token_service->generate('array', $breadcrump_by_ado_type_token, ['array' => $single_path], $options, $bubbleable_metadata);
+        //$replacements += $token_service->generate('array', $breadcrump_by_ado_type_tokens, ['array' => $single_path], $options, $bubbleable_metadata);
+      }
+    }
+
+
+
+
+
+
   }
-
-  /*if ($types_tokens = $token_service->findWithPrefix($tokens, 'types')) {
-    $replacements += $token_service->generate('array', $tokens, ['array' => ['ml','js']], $options, $bubbleable_metadata);
-  }*/
-
-  /*if ($entity_tokens = $token_service->findWithPrefix($tokens, 'node')) {
-    $replacements += $token_service->generate('node', $entity_tokens, ['node' => $source_entity], $options, $bubbleable_metadata);
-  }*/
-return $replacements;
-
+  return $replacements;
 }


### PR DESCRIPTION
Implements some basic but useful ADO Tokens. Not sure they are perfect, but they do their job as good as a token can do 


Tokens provided are  (using twig on preview mode for an ADO, here so one can test)
```Twig
{{ drupal_token('ado:type',{node}) }}
```

`[ado:type]` provides the top level "type" key value. String.

```Twig
{{ drupal_token('ado:types:join:,',{node}) }}
```
`[ado:types]` provides all Type keys (like ADO type to View Mode Mapper does). Array as output, so be used with a `:join`, or `:last` or any other `array` sub tokens

```Twig
{{ drupal_token('ado:breadcrumb_by_ado_type:collection:last',{node}) }}
```

`[ado:breadcrumb_by_ado_type:{an_ado_type}]` with {an_ado_type} being an ado type. Provides the longest parentship (breadcrumb) trail only including "labels" for ADOs in that Path found to be of  type  {an_ado_type} . Array as output, so be used with a `:join`, or `:last` or any other `array` sub tokens

```Twig
{{ drupal_token('node:ado:breadcrumb_by_relation:ismemberof:join:;',{node}) }}
```

`[ado: breadcrumb_by_relation:{a_predicate}]` with {a_predicate} being an a JSON key name holding a parent ADO. Provides the longest parentship (breadcrumb) trail only including "labels" for ADOs connected to another one via a key named  "a_predicate" . Array as output,  so be used with a `:join`, or `:last` or any other `array` sub tokens

For both of these, the order is based on closeness. 

Because many Modules require the "context" of having a NODE before calling a replacement (e.g Google Tag manager)

All these can also be called with the `node:` prefix.

e.g `[node: ado: breadcrumb_by_relation:{a_predicate}]


Anything that outputs `Arrays`, when not chained (e.g 

```Twig
{{ drupal_token('ado:types',{node}) }}
```

Will return a string representation (in this case the first type). Tokens can only produce strings.

@alliomeria thanks