### PR TITLE
ISSUE-376: (D10) Improve File extension sanitization (removes spaces/weird characters …

### DIFF
--- a/src/EventSubscriber/StrawberryfieldEventInsertSubscriberDepositDO.php
+++ b/src/EventSubscriber/StrawberryfieldEventInsertSubscriberDepositDO.php
@@ -195,11 +195,11 @@ class StrawberryfieldEventInsertSubscriberDepositDO extends StrawberryfieldEvent
     if (!$success) {
       $this->messenger->addError(
         t(
-          'Digital Object Serialization failed? We could not persist to Filesystem. Please contact your site admin.'
+          'Digital Object Serialization failed? We could not persist to Filesystem. Please contact your site admin and/or check your Drupal logs.'
         )
       );
       $this->loggerFactory->get('archipelago')->critical(
-        'Digital Object Serialization failed , we could not persist to Filesystem.',
+        'Digital Object Serialization failed , we could not persist to Filesystem. Check Filesystem space and permissions and ADO Storage (e.g S3) service uptime and logs.',
         ['Entity ID' => $entity->id(), 'Entity Title' => $entity->label()]
       );
     }

--- a/src/StrawberryfieldFileMetadataService.php
+++ b/src/StrawberryfieldFileMetadataService.php
@@ -688,6 +688,11 @@ class StrawberryfieldFileMetadataService {
     $uri = $file->getFileUri();
     // Local stream.
     $cache_key = $checksum ?? md5($uri);
+    $basename = basename($uri);
+    // Remove any spaces since unix commands could have issues with that.
+    // This normally should not be an issue at all since The File Persister
+    // Should have done this... but a power user could override it via a hook
+    $basename = preg_replace('/\s+/', '', $basename);
     // Check first if the file is already around in temp?
     // @TODO can be sure its the same one? Ideas?
     // If the file isn't stored locally make a temporary copy.
@@ -698,18 +703,18 @@ class StrawberryfieldFileMetadataService {
     )) {
       if (is_readable(
         $this->fileSystem->realpath(
-          'temporary://sbr_' . $cache_key . '_' . basename($uri)
+          'temporary://sbr_' . $cache_key . '_' . $basename
         )
       )) {
         $templocation = $this->fileSystem->realpath(
-          'temporary://sbr_' . $cache_key . '_' . basename($uri)
+          'temporary://sbr_' . $cache_key . '_' . $basename
         );
       }
       else {
         try {
           $templocation = $this->fileSystem->copy(
             $uri,
-            'temporary://sbr_' . $cache_key . '_' . basename($uri),
+            'temporary://sbr_' . $cache_key . '_' . $basename,
             FileSystemInterface::EXISTS_REPLACE
           );
           $templocation = $this->fileSystem->realpath(

--- a/src/StrawberryfieldFilePersisterService.php
+++ b/src/StrawberryfieldFilePersisterService.php
@@ -325,17 +325,32 @@ class StrawberryfieldFilePersisterService {
       $current_uri,
       PATHINFO_EXTENSION
     );
-    // Check if the file may have a secondary extension
+    // Remove any spaces from the main extension
+    $file_parts['destination_extension'] = preg_replace('/\s+/', '', $file_parts['destination_extension'] ?? '');
+    // Sanitize the extension too
+    $file_parts['destination_extension'] = $this->sanitizeFileName($file_parts['destination_extension']);
 
+    // Check if the file may have a secondary extension
     $file_parts['destination_extension_secondary'] = pathinfo(
       $file_parts['destination_filename'],
       PATHINFO_EXTENSION
     );
+    // Remove any spaces from the secondary extension
+    $file_parts['destination_extension_secondary'] = preg_replace('/\s+/', '', $file_parts['destination_extension_secondary'] ?? '');
     // Deal with 2 part extension problem.
     if (!empty($file_parts['destination_extension_secondary']) &&
       strlen($file_parts['destination_extension_secondary']) <= 4 &&
       strlen($file_parts['destination_extension_secondary']) > 0
     ) {
+      // If it had a second extension we need to remove that one from the file name
+      // by requesting again the pathinfo only for tile.
+      $file_parts['destination_filename'] = pathinfo(
+        $file_parts['destination_filename'],
+        PATHINFO_FILENAME
+      );
+      // Only if it qualifies as a secondary extension we sanitize. Since if not the actual base name will be completely
+      // sanitized.
+      $file_parts['destination_extension_secondary'] = $this->sanitizeFileName($file_parts['destination_extension_secondary']);
       $file_parts['destination_extension'] = $file_parts['destination_extension_secondary'] . '.' . $file_parts['destination_extension'];
     }
 
@@ -1205,38 +1220,43 @@ class StrawberryfieldFilePersisterService {
     $success = FALSE;
     $compress = (extension_loaded('zlib') && $compress);
     $onlycompressed = ($compress && $onlycompressed);
-    if (!empty($data) && !empty($path) && !empty($filename)) {
-      $success = TRUE;
-      $uri = $path . '/' . $filename;
+    try {
+      if (!empty($data) && !empty($path) && !empty($filename)) {
+        $success = TRUE;
+        $uri = $path . '/' . $filename;
 
-      if (!$this->fileSystem->prepareDirectory(
-        $path,
-        FileSystemInterface::CREATE_DIRECTORY
-      )) {
-        $success = FALSE;
-        return $success;
-      }
-
-      if (!$onlycompressed) {
-        if (!$this->fileSystem->saveData(
-          $data,
-          $uri,
-          FileSystemInterface::EXISTS_REPLACE
+        if (!$this->fileSystem->prepareDirectory(
+          $path,
+          FileSystemInterface::CREATE_DIRECTORY
         )) {
           $success = FALSE;
-          // We have to return early if this failed.
           return $success;
         }
-      }
-      if ($compress) {
-        if (!$this->fileSystem->saveData(
-          gzencode($data, 9, FORCE_GZIP),
-          $uri . '.gz',
-          FileSystemInterface::EXISTS_REPLACE
-        )) {
-          $success = FALSE;
+
+        if (!$onlycompressed) {
+          if (!$this->fileSystem->saveData(
+            $data,
+            $uri,
+            FileSystemInterface::EXISTS_REPLACE
+          )) {
+            $success = FALSE;
+            // We have to return early if this failed.
+            return $success;
+          }
+        }
+        if ($compress) {
+          if (!$this->fileSystem->saveData(
+            gzencode($data, 9, FORCE_GZIP),
+            $uri . '.gz',
+            FileSystemInterface::EXISTS_REPLACE
+          )) {
+            $success = FALSE;
+          }
         }
       }
+    }
+    catch (\Throwable $exception) {
+      $success = FALSE;
     }
     return $success;
   }


### PR DESCRIPTION
…now) and remove spaces form temp files + throwable catching on DO deposit

Also removes the secondary extension (if found) from the original filename, since we are adding it back (but only if found of course) and adds a try/catch (\Throwable $exception) when depositing an DO file representation  + a better error message if it fails

See #376 